### PR TITLE
feat: 로그인, 로그아웃, 토큰 재발급 기능 구현

### DIFF
--- a/prothsync/src/main/java/com/prothsync/prothsync/config/AuditConfig.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/config/AuditConfig.java
@@ -1,5 +1,6 @@
 package com.prothsync.prothsync.config;
 
+import com.prothsync.prothsync.security.CustomUserDetails;
 import java.util.Optional;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -26,12 +27,13 @@ public class AuditConfig {
             if (authentication == null
                 || !authentication.isAuthenticated()
                 || authentication instanceof AnonymousAuthenticationToken) {
-                // 비인증 사용자인 경우 (회원가입 등)
                 return Optional.of(0L);
             }
 
-            // 인증된 사용자인 경우 사용자 ID 반환
-            // 추후 JWT에서 추출한 userId를 반환하도록 수정
+            if (authentication.getPrincipal() instanceof CustomUserDetails userDetails) {
+                return Optional.of(userDetails.getUserId());
+            }
+
             return Optional.of(0L);
         }
     }

--- a/prothsync/src/main/java/com/prothsync/prothsync/config/SecurityConfig.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.prothsync.prothsync.config;
 
+import com.prothsync.prothsync.security.JwtAuthenticationEntryPoint;
+import com.prothsync.prothsync.security.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,11 +12,15 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -28,11 +34,15 @@ public class SecurityConfig {
             .sessionManagement(session -> session
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             )
+            .exceptionHandling(exception -> exception
+                .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+            )
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/api/auth/**").permitAll()
+                .requestMatchers("/api/auth/signup", "/api/auth/login", "/api/auth/refresh").permitAll()
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                 .anyRequest().authenticated()
-            );
+            )
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/AuthController.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/AuthController.java
@@ -1,16 +1,18 @@
 package com.prothsync.prothsync.controller;
 
+import com.prothsync.prothsync.dto.LoginRequestDTO;
+import com.prothsync.prothsync.dto.LoginResponseDTO;
 import com.prothsync.prothsync.dto.SignupRequestDTO;
 import com.prothsync.prothsync.dto.SignupResponseDTO;
+import com.prothsync.prothsync.dto.TokenRefreshRequestDTO;
+import com.prothsync.prothsync.dto.TokenRefreshResponseDTO;
 import com.prothsync.prothsync.entity.user.User;
+import com.prothsync.prothsync.security.CustomUserDetails;
 import com.prothsync.prothsync.service.AuthService;
 import jakarta.validation.Valid;
-import java.net.URI;
-import java.net.URL;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,10 +26,27 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/signup")
-    public ResponseEntity<SignupResponseDTO> signup(@Valid @RequestBody SignupRequestDTO signupRequest){
-
+    public ResponseEntity<SignupResponseDTO> signup(@Valid @RequestBody SignupRequestDTO signupRequest) {
         User user = authService.signup(signupRequest);
         return ResponseEntity.ok(SignupResponseDTO.from(user));
     }
 
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponseDTO> login(@Valid @RequestBody LoginRequestDTO loginRequest) {
+        LoginResponseDTO response = authService.login(loginRequest);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<TokenRefreshResponseDTO> refreshToken(
+        @Valid @RequestBody TokenRefreshRequestDTO refreshRequest) {
+        TokenRefreshResponseDTO response = authService.refreshToken(refreshRequest.refreshToken());
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        authService.logout(userDetails.getUserId());
+        return ResponseEntity.ok().build();
+    }
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/dto/LoginRequestDTO.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/dto/LoginRequestDTO.java
@@ -1,0 +1,13 @@
+package com.prothsync.prothsync.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequestDTO(
+
+    @NotBlank(message = "아이디는 필수입니다.")
+    String userName,
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    String password
+) {
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/dto/LoginResponseDTO.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/dto/LoginResponseDTO.java
@@ -1,0 +1,14 @@
+package com.prothsync.prothsync.dto;
+
+public record LoginResponseDTO(
+    String accessToken,
+    String refreshToken,
+    Long userId,
+    String userName,
+    String nickName
+) {
+    public static LoginResponseDTO of(String accessToken, String refreshToken,
+        Long userId, String userName, String nickName) {
+        return new LoginResponseDTO(accessToken, refreshToken, userId, userName, nickName);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/dto/TokenRefreshRequestDTO.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/dto/TokenRefreshRequestDTO.java
@@ -1,0 +1,10 @@
+package com.prothsync.prothsync.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TokenRefreshRequestDTO(
+
+    @NotBlank(message = "리프레시 토큰은 필수입니다.")
+    String refreshToken
+) {
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/dto/TokenRefreshResponseDTO.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/dto/TokenRefreshResponseDTO.java
@@ -1,0 +1,10 @@
+package com.prothsync.prothsync.dto;
+
+public record TokenRefreshResponseDTO(
+    String accessToken,
+    String refreshToken
+) {
+    public static TokenRefreshResponseDTO of(String accessToken, String refreshToken) {
+        return new TokenRefreshResponseDTO(accessToken, refreshToken);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/RefreshToken.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/RefreshToken.java
@@ -1,0 +1,52 @@
+package com.prothsync.prothsync.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "refresh_tokens")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private Long userId;
+
+    @Column(nullable = false, length = 500)
+    private String token;
+
+    @Column(nullable = false)
+    private LocalDateTime expiredAt;
+
+    private RefreshToken(Long userId, String token, LocalDateTime expiredAt) {
+        this.userId = userId;
+        this.token = token;
+        this.expiredAt = expiredAt;
+    }
+
+    public static RefreshToken create(Long userId, String token, long expirationMillis) {
+        LocalDateTime expiresAt = LocalDateTime.now().plusNanos(expirationMillis * 1_000_000);
+        return new RefreshToken(userId, token, expiresAt);
+    }
+
+    public void updateToken(String newToken, long expirationMillis) {
+        this.token = newToken;
+        this.expiredAt = LocalDateTime.now().plusNanos(expirationMillis * 1_000_000);
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiredAt);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/exception/AuthErrorCode.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/exception/AuthErrorCode.java
@@ -1,0 +1,21 @@
+package com.prothsync.prothsync.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCode implements ErrorCode {
+
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 올바르지 않습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "리프레시 토큰을 찾을 수 없습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/RefreshTokenRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/RefreshTokenRepositoryImpl.java
@@ -1,0 +1,35 @@
+package com.prothsync.prothsync.repository.impl;
+
+import com.prothsync.prothsync.entity.RefreshToken;
+import com.prothsync.prothsync.repository.jpa.RefreshTokenJpaRepository;
+import com.prothsync.prothsync.repository.repository.RefreshTokenRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class RefreshTokenRepositoryImpl implements RefreshTokenRepository {
+
+    private final RefreshTokenJpaRepository refreshTokenJpaRepository;
+
+    @Override
+    public RefreshToken save(RefreshToken refreshToken) {
+        return refreshTokenJpaRepository.save(refreshToken);
+    }
+
+    @Override
+    public Optional<RefreshToken> findByUserId(Long userId) {
+        return refreshTokenJpaRepository.findByUserId(userId);
+    }
+
+    @Override
+    public Optional<RefreshToken> findByToken(String token) {
+        return refreshTokenJpaRepository.findByToken(token);
+    }
+
+    @Override
+    public void deleteByUserId(Long userId) {
+        refreshTokenJpaRepository.deleteByUserId(userId);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/UserRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/UserRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.prothsync.prothsync.repository.impl;
 import com.prothsync.prothsync.entity.user.User;
 import com.prothsync.prothsync.repository.jpa.UserJpaRepository;
 import com.prothsync.prothsync.repository.repository.UserRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -30,5 +31,15 @@ public class UserRepositoryImpl implements UserRepository {
     @Override
     public boolean existsByEmail(String email) {
         return userJpaRepository.existsByEmail(email);
+    }
+
+    @Override
+    public Optional<User> findById(Long userId) {
+        return userJpaRepository.findById(userId);
+    }
+
+    @Override
+    public Optional<User> findByUserName(String userName) {
+        return userJpaRepository.findByUserName(userName);
     }
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/RefreshTokenJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/RefreshTokenJpaRepository.java
@@ -1,0 +1,14 @@
+package com.prothsync.prothsync.repository.jpa;
+
+import com.prothsync.prothsync.entity.RefreshToken;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenJpaRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByUserId(Long userId);
+
+    Optional<RefreshToken> findByToken(String token);
+
+    void deleteByUserId(Long userId);
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/UserJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/UserJpaRepository.java
@@ -1,6 +1,7 @@
 package com.prothsync.prothsync.repository.jpa;
 
 import com.prothsync.prothsync.entity.user.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserJpaRepository extends JpaRepository<User, Long> {
@@ -10,6 +11,8 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
     boolean existsByNickName(String nickName);
 
     boolean existsByEmail(String email);
+
+    Optional<User> findByUserName(String userName);
 
 
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/RefreshTokenRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/RefreshTokenRepository.java
@@ -1,0 +1,15 @@
+package com.prothsync.prothsync.repository.repository;
+
+import com.prothsync.prothsync.entity.RefreshToken;
+import java.util.Optional;
+
+public interface RefreshTokenRepository {
+
+    RefreshToken save(RefreshToken refreshToken);
+
+    Optional<RefreshToken> findByUserId(Long userId);
+
+    Optional<RefreshToken> findByToken(String token);
+
+    void deleteByUserId(Long userId);
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/UserRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.prothsync.prothsync.repository.repository;
 
 import com.prothsync.prothsync.entity.user.User;
+import java.util.Optional;
 
 public interface UserRepository {
 
@@ -8,4 +9,6 @@ public interface UserRepository {
     boolean existsByUserName(String userName);
     boolean existsByNickName(String nickName);
     boolean existsByEmail(String email);
+    Optional<User> findById(Long userId);
+    Optional<User> findByUserName(String userName);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/security/CustomUserDetails.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/security/CustomUserDetails.java
@@ -1,0 +1,56 @@
+package com.prothsync.prothsync.security;
+
+import com.prothsync.prothsync.entity.user.User;
+import java.util.Collection;
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final User user;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + user.getUserRole().name()));
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUserName();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return !user.isDeleted();
+    }
+
+    public Long getUserId() {
+        return user.getUserId();
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/security/CustomUserDetailsService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/security/CustomUserDetailsService.java
@@ -1,0 +1,33 @@
+package com.prothsync.prothsync.security;
+
+import com.prothsync.prothsync.entity.user.User;
+import com.prothsync.prothsync.exception.BusinessException;
+import com.prothsync.prothsync.exception.UserErrorCode;
+import com.prothsync.prothsync.repository.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByUserName(username)
+            .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + username));
+
+        return new CustomUserDetails(user);
+    }
+
+    public UserDetails loadUserById(Long userId) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        return new CustomUserDetails(user);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/security/JwtAuthenticationEntryPoint.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,39 @@
+package com.prothsync.prothsync.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.prothsync.prothsync.exception.AuthErrorCode;
+import com.prothsync.prothsync.exception.ErrorResponse;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request,
+        HttpServletResponse response,
+        AuthenticationException authException) throws IOException, ServletException {
+
+        log.warn("Unauthorized error: {}", authException.getMessage());
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        ErrorResponse errorResponse = ErrorResponse.of(AuthErrorCode.UNAUTHORIZED);
+
+        objectMapper.writeValue(response.getOutputStream(), errorResponse);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/security/JwtAuthenticationFilter.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/security/JwtAuthenticationFilter.java
@@ -1,0 +1,65 @@
+package com.prothsync.prothsync.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final CustomUserDetailsService customUserDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+
+        String token = resolveToken(request);
+
+        if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+            if (jwtTokenProvider.isAccessToken(token)) {
+                Long userId = jwtTokenProvider.getUserId(token);
+                UserDetails userDetails = customUserDetailsService.loadUserById(userId);
+
+                UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(
+                        userDetails,
+                        null,
+                        userDetails.getAuthorities()
+                    );
+
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(BEARER_PREFIX.length());
+        }
+
+        return null;
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/security/JwtTokenProvider.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/security/JwtTokenProvider.java
@@ -1,0 +1,122 @@
+package com.prothsync.prothsync.security;
+
+import com.prothsync.prothsync.entity.user.UserType;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SecurityException;
+import jakarta.annotation.PostConstruct;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret}")
+    private String secretKeyString;
+
+    @Value("${jwt.access-token-expiration}")
+    private long accessTokenExpiration;
+
+    @Value("${jwt.refresh-token-expiration}")
+    private long refreshTokenExpiration;
+
+    private SecretKey secretKey;
+
+    @PostConstruct
+    public void init() {
+        this.secretKey = Keys.hmacShaKeyFor(secretKeyString.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String createAccessToken(Long userId, String userName, UserType userType) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + accessTokenExpiration);
+
+        return Jwts.builder()
+            .subject(String.valueOf(userId))
+            .claim("userName", userName)
+            .claim("userType", userType.toString())
+            .claim("tokenType", "ACCESS")
+            .issuedAt(now)
+            .expiration(expiry)
+            .signWith(secretKey)
+            .compact();
+    }
+
+    public String createRefreshToken(Long userId) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + refreshTokenExpiration);
+
+        return Jwts.builder()
+            .subject(String.valueOf(userId))
+            .claim("tokenType", "REFRESH")
+            .issuedAt(now)
+            .expiration(expiry)
+            .signWith(secretKey)
+            .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.warn("잘못된 JWT 서명입니다.");
+        } catch (ExpiredJwtException e) {
+            log.warn("만료된 JWT 토큰입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.warn("지원되지 않는 JWT 토큰입니다.");
+        } catch (IllegalArgumentException e) {
+            log.warn("JWT 토큰이 비어있습니다.");
+        }
+        return false;
+    }
+
+    public Long getUserId(String token) {
+        Claims claims = parseClaims(token);
+        return Long.parseLong(claims.getSubject());
+    }
+
+    public String getUserName(String token) {
+        Claims claims = parseClaims(token);
+        return claims.get("userName", String.class);
+    }
+
+    public String getUserType(String token) {
+        Claims claims = parseClaims(token);
+        return claims.get("userType", String.class);
+    }
+
+    public boolean isAccessToken(String token) {
+        Claims claims = parseClaims(token);
+        return "ACCESS".equals(claims.get("tokenType", String.class));
+    }
+
+    public boolean isRefreshToken(String token) {
+        Claims claims = parseClaims(token);
+        return "REFRESH".equals(claims.get("tokenType", String.class));
+    }
+
+    public long getRefreshTokenExpiration() {
+        return refreshTokenExpiration;
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parser()
+            .verifyWith(secretKey)
+            .build()
+            .parseSignedClaims(token)
+            .getPayload();
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/AuthService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/AuthService.java
@@ -1,12 +1,18 @@
 package com.prothsync.prothsync.service;
 
+import com.prothsync.prothsync.dto.LoginRequestDTO;
+import com.prothsync.prothsync.dto.LoginResponseDTO;
 import com.prothsync.prothsync.dto.SignupRequestDTO;
+import com.prothsync.prothsync.dto.TokenRefreshResponseDTO;
+import com.prothsync.prothsync.entity.RefreshToken;
 import com.prothsync.prothsync.entity.user.User;
+import com.prothsync.prothsync.exception.AuthErrorCode;
 import com.prothsync.prothsync.exception.BusinessException;
 import com.prothsync.prothsync.exception.UserErrorCode;
+import com.prothsync.prothsync.repository.repository.RefreshTokenRepository;
 import com.prothsync.prothsync.repository.repository.UserRepository;
+import com.prothsync.prothsync.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,12 +22,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthService {
 
     private final UserRepository userRepository;
-
+    private final RefreshTokenRepository refreshTokenRepository;
     private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Transactional
-    public User signup(SignupRequestDTO signupRequest){
-
+    public User signup(SignupRequestDTO signupRequest) {
         validateDuplicateUserName(signupRequest.userName());
         validateDuplicateNickName(signupRequest.nickName());
         validateDuplicateEmail(signupRequest.email());
@@ -41,6 +47,83 @@ public class AuthService {
         return userRepository.save(user);
     }
 
+    @Transactional
+    public LoginResponseDTO login(LoginRequestDTO loginRequest) {
+        User user = userRepository.findByUserName(loginRequest.userName())
+            .orElseThrow(() -> new BusinessException(AuthErrorCode.INVALID_CREDENTIALS));
+
+        if (!passwordEncoder.matches(loginRequest.password(), user.getPassword())) {
+            throw new BusinessException(AuthErrorCode.INVALID_CREDENTIALS);
+        }
+
+        String accessToken = jwtTokenProvider.createAccessToken(user.getUserId(), user.getUserName(),user.getUserType());
+        String refreshToken = jwtTokenProvider.createRefreshToken(user.getUserId());
+
+        saveOrUpdateRefreshToken(user.getUserId(), refreshToken);
+
+        return LoginResponseDTO.of(
+            accessToken,
+            refreshToken,
+            user.getUserId(),
+            user.getUserName(),
+            user.getNickName()
+        );
+    }
+
+    @Transactional
+    public TokenRefreshResponseDTO refreshToken(String refreshTokenValue) {
+        if (!jwtTokenProvider.validateToken(refreshTokenValue)) {
+            throw new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        if (!jwtTokenProvider.isRefreshToken(refreshTokenValue)) {
+            throw new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        RefreshToken storedToken = refreshTokenRepository.findByToken(refreshTokenValue)
+            .orElseThrow(() -> new BusinessException(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND));
+
+        if (storedToken.isExpired()) {
+            refreshTokenRepository.deleteByUserId(storedToken.getUserId());
+            throw new BusinessException(AuthErrorCode.EXPIRED_TOKEN);
+        }
+
+        Long userId = storedToken.getUserId();
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        String newAccessToken = jwtTokenProvider.createAccessToken(user.getUserId(), user.getUserName(), user.getUserType());
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(user.getUserId());
+
+        storedToken.updateToken(newRefreshToken, jwtTokenProvider.getRefreshTokenExpiration());
+        refreshTokenRepository.save(storedToken);
+
+        return TokenRefreshResponseDTO.of(newAccessToken, newRefreshToken);
+    }
+
+    @Transactional
+    public void logout(Long userId) {
+        refreshTokenRepository.deleteByUserId(userId);
+    }
+
+    private void saveOrUpdateRefreshToken(Long userId, String refreshToken) {
+        refreshTokenRepository.findByUserId(userId)
+            .ifPresentOrElse(
+                token -> {
+                    token.updateToken(refreshToken, jwtTokenProvider.getRefreshTokenExpiration());
+                    refreshTokenRepository.save(token);
+                },
+                () -> {
+                    RefreshToken newToken = RefreshToken.create(
+                        userId,
+                        refreshToken,
+                        jwtTokenProvider.getRefreshTokenExpiration()
+                    );
+                    refreshTokenRepository.save(newToken);
+                }
+            );
+    }
+
     private void validateDuplicateUserName(String userName) {
         if (userRepository.existsByUserName(userName)) {
             throw new BusinessException(UserErrorCode.DUPLICATE_USERNAME);
@@ -58,5 +141,4 @@ public class AuthService {
             throw new BusinessException(UserErrorCode.DUPLICATE_EMAIL);
         }
     }
-
 }

--- a/prothsync/src/main/resources/application.yaml
+++ b/prothsync/src/main/resources/application.yaml
@@ -18,6 +18,6 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
 
 jwt:
-  secret: prothsync-jwt-secret-key-must-be-at-least-256-bits-long-for-hs256
-  access-token-expiration: 1800000
-  refresh-token-expiration: 604800000
+  secret: ${JWT_SECRET}
+  access-token-expiration: ${JWT_ACCESS_EXPIRATION:1800000}
+  refresh-token-expiration: ${JWT_REFRESH_EXPIRATION:604800000}


### PR DESCRIPTION
# 개요
- 회원가입 이후 로그인/로그아웃/토큰 갱신 기능을 JWT 기반으로 구현했습니다.

## RefreshToken을 DB에 저장한 이유
- 우선은 추가 인프라 없이 즉시 사용 가능
- 현재 Repository 추상화로 인하여 추후에 Redis로 전환 용이
- 로그아웃 시 즉시 무효화 가능

## RefreshToken을 Body로 전달하는 이유
- HttpOnly 쿠키 방식도 고려했으나, 웹과 모바일 앱 동시 지원을 목표로 하기 위해 Body 방식 선택

## 향후 계획
- 트래픽 증가 시 Refresh Token 저장소를 Redis로 전환
- Access Token 블랙리스트 

## 인증 플로우
```
[로그인]
POST /api/auth/login
     ↓
비밀번호 검증 → Access Token (30분) + Refresh Token (7일) 발급
     ↓
Response Body로 토큰 전달

[API 호출]
Authorization: Bearer {accessToken}
     ↓
JwtAuthenticationFilter에서 토큰 검증
     ↓
SecurityContext에 인증 정보 저장
     ↓
Controller에서 @AuthenticationPrincipal로 사용자 정보 접근

[토큰 갱신]
POST /api/auth/refresh { refreshToken }
     ↓
Refresh Token 검증 → 새 토큰 쌍 발급 (Rotation)

[로그아웃]
POST /api/auth/logout
     ↓
DB에서 Refresh Token 삭제
```



## 