### PR TITLE
feat: 토큰 블랙리스트 기능 구현, 스웨거 설정, 각 api 실행시간 config 파일 추가

### DIFF
--- a/prothsync/build.gradle
+++ b/prothsync/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	developmentOnly 'org.springframework.boot:spring-boot-docker-compose'

--- a/prothsync/compose.yaml
+++ b/prothsync/compose.yaml
@@ -14,9 +14,23 @@ services:
     networks:
       - db-net
 
+  redis-prothSync:
+    image: 'redis:7-alpine'
+    container_name: redis-prothSync
+    command: redis-server --requirepass ${REDIS_PASSWORD}
+    environment:
+      TZ: ${TZ}
+    ports:
+      - "6379:6379"
+    networks:
+      - db-net
+    volumes:
+      - prothSync_redis_data:/data
+
 networks:
   db-net:
     name: db-net
 
 volumes:
   prothSync_postgres_data:
+  prothSync_redis_data:

--- a/prothsync/src/main/java/com/prothsync/prothsync/config/ExecutionTimeConfig.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/config/ExecutionTimeConfig.java
@@ -1,0 +1,71 @@
+package com.prothsync.prothsync.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Slf4j(topic = "API_PERFORMANCE")
+@Aspect
+@Component
+public class ExecutionTimeConfig {
+
+    @Around("execution(* com.prothsync.prothsync.controller..*(..))")
+    public Object logExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+        long startTime = System.currentTimeMillis();
+
+        ServletRequestAttributes attributes =
+            (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+
+        String methodName = joinPoint.getSignature().toShortString();
+        String httpMethod = null;
+        String requestUri = null;
+
+        if (attributes != null) {
+            HttpServletRequest request = attributes.getRequest();
+            httpMethod = request.getMethod();
+            requestUri = request.getRequestURI();
+        }
+
+        try {
+            // 실제 메서드 실행
+            Object result = joinPoint.proceed();
+
+            long executionTime = System.currentTimeMillis() - startTime;
+
+            // 실행 시간 로깅
+            if (attributes != null) {
+                log.info("[{}] {} {} - 실행 시간: {}ms",
+                    httpMethod, requestUri, methodName, executionTime);
+            } else {
+                log.info("{} - 실행시간: {}ms", methodName, executionTime);
+            }
+
+            // 성능 경고 (1초 이상 소요시)
+            if (executionTime > 1000) {
+                log.warn("⚠️ SLOW API DETECTED: {} took {}ms", methodName, executionTime);
+            }
+
+            return result;
+
+        } catch (Throwable throwable) {
+            long executionTime = System.currentTimeMillis() - startTime;
+
+            if (attributes != null) {
+                log.error("[{}] {} {} - Failed after {}ms - Error: {}",
+                    httpMethod, requestUri, methodName, executionTime,
+                    throwable.getMessage());
+            } else {
+                log.error("{} - Failed after {}ms - Error: {}",
+                    methodName, executionTime, throwable.getMessage());
+            }
+
+            throw throwable;
+        }
+    }
+
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/config/RedisConfig.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/config/RedisConfig.java
@@ -1,0 +1,25 @@
+package com.prothsync.prothsync.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectFactory);
+
+        StringRedisSerializer serializer = new StringRedisSerializer();
+        template.setKeySerializer(serializer);
+        template.setHashKeySerializer(serializer);
+        template.setValueSerializer(serializer);
+        template.setHashValueSerializer(serializer);
+
+        return template;
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/config/SwaggerConfig.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/config/SwaggerConfig.java
@@ -1,0 +1,39 @@
+package com.prothsync.prothsync.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+            .info(apiInfo())
+            .components(new Components()
+                .addSecuritySchemes("bearerAuth", securityScheme()));
+    }
+
+    private Info apiInfo() {
+        return new Info()
+            .title("ProthSync API")
+            .description("치아 관련 포트폴리오 통합 사이트")
+            .version("v1.0.0")
+            .contact(new Contact()
+                .name("JC")
+                .email("p990805@naver.com"));
+    }
+
+    private SecurityScheme securityScheme() {
+        return new SecurityScheme()
+            .type(SecurityScheme.Type.HTTP)
+            .scheme("bearer")
+            .bearerFormat("JWT")
+            .description("JWT Access Token을 입력하세요. (Bearer 접두사 불필요)");
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/AuthControllerDocs.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/AuthControllerDocs.java
@@ -1,0 +1,106 @@
+package com.prothsync.prothsync.controller.docs;
+
+import com.prothsync.prothsync.dto.LoginRequestDTO;
+import com.prothsync.prothsync.dto.LoginResponseDTO;
+import com.prothsync.prothsync.dto.SignupRequestDTO;
+import com.prothsync.prothsync.dto.SignupResponseDTO;
+import com.prothsync.prothsync.dto.TokenRefreshRequestDTO;
+import com.prothsync.prothsync.dto.TokenRefreshResponseDTO;
+import com.prothsync.prothsync.exception.ErrorResponse;
+import com.prothsync.prothsync.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "인증", description = "회원가입, 로그인, 로그아웃, 토큰 갱신 API")
+public interface AuthControllerDocs {
+
+    @Operation(summary = "회원가입", description = "신규 사용자를 등록합니다.")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "회원가입 성공",
+            content = @Content(schema = @Schema(implementation = SignupResponseDTO.class))
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "유효성 검증 실패 (필수 필드 누락, 형식 오류 등)",
+            content = @Content(schema = @Schema(implementation = String.class))
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description = "중복된 아이디/닉네임/이메일",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<SignupResponseDTO> signup(SignupRequestDTO signupRequest);
+
+    @Operation(summary = "로그인", description = "아이디와 비밀번호로 로그인하여 JWT 토큰을 발급받습니다.")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "로그인 성공",
+            content = @Content(schema = @Schema(implementation = LoginResponseDTO.class))
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "유효성 검증 실패",
+            content = @Content(schema = @Schema(implementation = String.class))
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description = "아이디 또는 비밀번호 불일치",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        ),
+        @ApiResponse(
+            responseCode = "423",
+            description = "계정 잠금 (로그인 시도 초과)",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<LoginResponseDTO> login(LoginRequestDTO loginRequest);
+
+    @Operation(summary = "토큰 갱신", description = "Refresh Token을 사용하여 새로운 Access Token과 Refresh Token을 발급받습니다.")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "토큰 갱신 성공",
+            content = @Content(schema = @Schema(implementation = TokenRefreshResponseDTO.class))
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "유효성 검증 실패",
+            content = @Content(schema = @Schema(implementation = String.class))
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description = "유효하지 않거나 만료된 Refresh Token",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<TokenRefreshResponseDTO> refreshToken(TokenRefreshRequestDTO refreshRequest);
+
+    @Operation(
+        summary = "로그아웃",
+        description = "현재 사용자를 로그아웃하고 토큰을 무효화합니다.",
+        security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "로그아웃 성공"
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description = "인증 필요 또는 유효하지 않은 토큰",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<Void> logout(CustomUserDetails userDetails, HttpServletRequest request);
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/dto/SignupRequestDTO.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/dto/SignupRequestDTO.java
@@ -1,37 +1,54 @@
 package com.prothsync.prothsync.dto;
 
 import com.prothsync.prothsync.entity.user.UserType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 
+@Schema(description = "회원가입 요청 DTO")
 public record SignupRequestDTO(
 
+    @Schema(description = "사용자 아이디", example = "testuser123", minLength = 5, maxLength = 20)
     @NotBlank(message = "사용자명은 필수입니다.")
     @Size(min = 5, max = 20, message = "사용자명은 5자 이상 20자 이하여야 합니다.")
     String userName,
 
+    @Schema(
+        description = "비밀번호 (8자 이상, 영문/숫자/특수문자 포함)",
+        example = "Password123!"
+    )
     @NotBlank(message = "비밀번호는 필수입니다.")
+    @Pattern(
+        regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$",
+        message = "비밀번호는 8자 이상, 영문/숫자/특수문자를 각각 포함해야 합니다."
+    )
     String password,
 
+    @Schema(description = "닉네임", example = "치과왕", maxLength = 10)
     @NotBlank(message = "닉네임은 필수입니다.")
     @Size(max = 10, message = "닉네임은 10자를 초과할 수 없습니다.")
     String nickName,
 
+    @Schema(description = "생년월일", example = "1990-01-15")
     @NotNull(message = "생년월일은 필수입니다.")
     @Past(message = "생년월일은 과거 날짜여야 합니다.")
     LocalDate birthday,
 
+    @Schema(description = "주소", example = "서울시 강남구 테헤란로 123")
     @NotBlank(message = "주소는 필수입니다.")
     String address,
 
+    @Schema(description = "이메일", example = "user@example.com")
     @NotBlank(message = "이메일은 필수입니다.")
     @Email(message = "유효한 이메일 형식이 아닙니다.")
     String email,
 
+    @Schema(description = "사용자 유형", example = "DENTIST")
     @NotNull(message = "사용자 유형은 필수입니다.")
     UserType userType
 ) {

--- a/prothsync/src/main/java/com/prothsync/prothsync/exception/JwtErrorCode.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/exception/JwtErrorCode.java
@@ -1,0 +1,21 @@
+package com.prothsync.prothsync.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum JwtErrorCode implements ErrorCode {
+
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
+    BLACKLISTED_TOKEN(HttpStatus.UNAUTHORIZED, "로그아웃된 토큰입니다."),
+    MALFORMED_TOKEN(HttpStatus.UNAUTHORIZED, "잘못된 형식의 토큰입니다."),
+    UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "지원하지 않는 토큰입니다."),
+    EMPTY_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 비어있습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/security/JwtAuthenticationFilter.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/security/JwtAuthenticationFilter.java
@@ -1,5 +1,10 @@
 package com.prothsync.prothsync.security;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.prothsync.prothsync.exception.ErrorCode;
+import com.prothsync.prothsync.exception.ErrorResponse;
+import com.prothsync.prothsync.exception.JwtErrorCode;
+import com.prothsync.prothsync.service.TokenBlacklistService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -7,6 +12,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -25,6 +31,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final CustomUserDetailsService customUserDetailsService;
+    private final TokenBlacklistService tokenBlacklistService;
+    private final ObjectMapper objectMapper;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -33,24 +41,43 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         String token = resolveToken(request);
 
-        if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
-            if (jwtTokenProvider.isAccessToken(token)) {
-                Long userId = jwtTokenProvider.getUserId(token);
-                UserDetails userDetails = customUserDetailsService.loadUserById(userId);
+        if (StringUtils.hasText(token)) {
+            if (tokenBlacklistService.isBlackListed(token)) {
+                log.warn("블랙리스트에 등록된 토큰입니다.");
+                sendErrorResponse(response, JwtErrorCode.BLACKLISTED_TOKEN);
+                return;
+            }
 
-                UsernamePasswordAuthenticationToken authentication =
-                    new UsernamePasswordAuthenticationToken(
-                        userDetails,
-                        null,
-                        userDetails.getAuthorities()
-                    );
+            if (jwtTokenProvider.validateToken(token)) {
+                if (jwtTokenProvider.isAccessToken(token)) {
+                    Long userId = jwtTokenProvider.getUserId(token);
+                    UserDetails userDetails = customUserDetailsService.loadUserById(userId);
 
-                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-                SecurityContextHolder.getContext().setAuthentication(authentication);
+                    UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(
+                            userDetails,
+                            null,
+                            userDetails.getAuthorities()
+                        );
+
+                    authentication.setDetails(
+                        new WebAuthenticationDetailsSource().buildDetails(request));
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
             }
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    private void sendErrorResponse(HttpServletResponse response, ErrorCode errorCode)
+        throws IOException {
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        ErrorResponse errorResponse = ErrorResponse.of(errorCode);
+        objectMapper.writeValue(response.getOutputStream(), errorResponse);
     }
 
     private String resolveToken(HttpServletRequest request) {

--- a/prothsync/src/main/java/com/prothsync/prothsync/security/JwtTokenProvider.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/security/JwtTokenProvider.java
@@ -10,6 +10,7 @@ import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.security.SecurityException;
 import jakarta.annotation.PostConstruct;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Date;
 import javax.crypto.SecretKey;
 import lombok.extern.slf4j.Slf4j;
@@ -111,6 +112,22 @@ public class JwtTokenProvider {
     public long getRefreshTokenExpiration() {
         return refreshTokenExpiration;
     }
+
+    public Duration getRemainingTime(String token) {
+        Claims claims = parseClaims(token);
+        Date expiration = claims.getExpiration();
+        Date now = new Date();
+
+        long remainingMillis = expiration.getTime() - now.getTime();
+
+        if (remainingMillis <= 0) {
+            return Duration.ZERO;
+        }
+
+        return Duration.ofMillis(remainingMillis);
+    }
+
+
 
     private Claims parseClaims(String token) {
         return Jwts.parser()

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/RedisTokenBlacklistService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/RedisTokenBlacklistService.java
@@ -1,0 +1,45 @@
+package com.prothsync.prothsync.service;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisTokenBlacklistService implements TokenBlacklistService {
+
+    private static final String BLACKLIST_PREFIX = "blacklist:token:";
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Override
+    public void addToBlackList(String token, Duration expirationTime) {
+        if (token == null || token.isBlank()) {
+            log.warn("토큰이 null이거나 비어있어 블랙리스트에 추가할 수 없습니다.");
+            return;
+        }
+
+        if (expirationTime == null || expirationTime.isNegative() || expirationTime.isZero()) {
+            log.warn("만료 시간이 유효하지 않아 블랙리스트에 추가할 수 없습니다.");
+            return;
+        }
+
+        String key = BLACKLIST_PREFIX + token;
+        redisTemplate.opsForValue().set(key, "LOGGED_OUT", expirationTime);
+        log.debug("토큰이 블랙리스트에 추가되었습니다. 만료 시간: {}초", expirationTime.getSeconds());
+    }
+
+    @Override
+    public boolean isBlackListed(String token) {
+        if (token == null || token.isBlank()) {
+            return false;
+        }
+
+        String key = BLACKLIST_PREFIX + token;
+        Boolean hasKey = redisTemplate.hasKey(key);
+        return Boolean.TRUE.equals(hasKey);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/TokenBlacklistService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/TokenBlacklistService.java
@@ -1,0 +1,10 @@
+package com.prothsync.prothsync.service;
+
+import java.time.Duration;
+
+public interface TokenBlacklistService {
+
+    void addToBlackList(String token, Duration expirationTime);
+
+    boolean isBlackListed(String token);
+}

--- a/prothsync/src/main/resources/application.yaml
+++ b/prothsync/src/main/resources/application.yaml
@@ -17,6 +17,12 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password: ${REDIS_PASSWORD}
+
 jwt:
   secret: ${JWT_SECRET}
   access-token-expiration: ${JWT_ACCESS_EXPIRATION:1800000}


### PR DESCRIPTION
# 변경사항

## 1. 토큰 블랙리스트 기능 구현
- Redis vs DB
- Redis로 선택한 이유는 아무래도 토큰 문제다 보니 매 인증 요청마다 조회하므로 성능이 중요하고 토큰 만료 시 자동 삭제가 필요하여 Redis의 TTL 기능을 선택하였습니다.

## 작동 방식

### 로그아웃 시
```
[Client] POST /api/auth/logout
    ↓
[AuthService] 
    1. Refresh Token 삭제 (DB)
    2. Access Token 남은 만료시간 계산
    3. Redis에 블랙리스트 등록 (TTL = 남은 만료시간)
    ↓
[Redis] blacklist:token:{jwt} = "LOGGED_OUT" (TTL: 남은시간)
```

### 인증 요청 시
```
[Client] GET /api/protected (Authorization: Bearer {token})
    ↓
[JwtAuthenticationFilter]
    1. 토큰 추출
    2. Redis 블랙리스트 조회 ← O(1) 조회
    3-a. 블랙리스트 존재 → 401 반환 (BLACKLISTED_TOKEN)
    3-b. 블랙리스트 없음 → 토큰 검증 진행
```
---

## 2. API 명세를 위한 Swagger 도입
- API 명세를 위한 swagger를 도입하였습니다.

---

## 3. 추후에 성능 개선이 필요할 것 같아서 컨트롤러에서 api가 발생하면 api의 실행 시간을 측정해주는 config설정도 하나 추가했습니다.

---

## 4. Redis를 사용하기 때문에 Docker와 env 파일에 redis관련한 설정 값을 추가하였습니다. 