### PR TITLE
feat: Post 좋아요 및 댓글 Entity 작성

### DIFF
--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/post/Comment.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/post/Comment.java
@@ -1,0 +1,81 @@
+package com.prothsync.prothsync.entity.post;
+
+import com.prothsync.prothsync.common.BaseEntity;
+import com.prothsync.prothsync.exception.BusinessException;
+import com.prothsync.prothsync.exception.PostErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "comments" )
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends BaseEntity {
+
+    private static final int MAX_CONTENT_LENGTH = 500;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long commentId;
+
+    @Column(name = "post_id", nullable = false)
+    private Long postId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, length = 500)
+    private String content;
+
+    private Comment(Long postId, Long userId, String content) {
+        this.postId = postId;
+        this.userId = userId;
+        this.content = content;
+    }
+
+    public static Comment createComment(Long postId, Long userId, String content) {
+        validatePostId(postId);
+        validateUserId(userId);
+        validateContent(content);
+
+        return new Comment(postId, userId, content);
+    }
+
+    private static void validatePostId(Long postId) {
+        if (postId == null) {
+            throw new BusinessException(PostErrorCode.POST_ID_NULL);
+        }
+    }
+
+    private static void validateUserId(Long userId) {
+        if (userId == null) {
+            throw new BusinessException(PostErrorCode.POST_USERID_NULL);
+        }
+    }
+
+    private static void validateContent(String content) {
+        if (content == null || content.isBlank()) {
+            throw new BusinessException(PostErrorCode.POST_CONTENT_NULL);
+        }
+        if (content.length() > MAX_CONTENT_LENGTH) {
+            throw new IllegalArgumentException("댓글은 " + MAX_CONTENT_LENGTH + "자를 초과할 수 없습니다.");
+        }
+    }
+
+    public void updateContent(String content) {
+        validateContent(content);
+        this.content = content;
+    }
+
+    public boolean isOwnedBy(Long userId) {
+        return this.userId.equals(userId);
+    }
+
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/post/PostLike.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/post/PostLike.java
@@ -1,0 +1,68 @@
+package com.prothsync.prothsync.entity.post;
+
+import com.prothsync.prothsync.common.BaseEntity;
+import com.prothsync.prothsync.exception.BusinessException;
+import com.prothsync.prothsync.exception.PostErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+    name = "post_likes",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_post_likes_user_post",
+            columnNames = {"user_id","post_id"}
+        )
+    }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostLike extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long likeId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "post_id", nullable = false)
+    private Long postId;
+
+    private PostLike(Long userId, Long postId) {
+        this.userId = userId;
+        this.postId = postId;
+    }
+
+    public static PostLike create(Long userId, Long postId) {
+        validateUserId(userId);
+        validatePostId(postId);
+
+        return new PostLike(userId, postId);
+    }
+
+    private static void validateUserId(Long userId) {
+        if (userId == null) {
+            throw new BusinessException(PostErrorCode.POST_USERID_NULL);
+        }
+    }
+
+    private static void validatePostId(Long postId) {
+        if (postId == null) {
+            throw new BusinessException(PostErrorCode.POST_ID_NULL);
+        }
+    }
+
+    public boolean isOwnedBy(Long userId) {
+        return this.userId.equals(userId);
+    }
+}


### PR DESCRIPTION
# 변경 사항

## 1. Comment Entity 구성
- 간단한 댓글 엔티티 구성 
- 아직 댓글에 대한 대댓글에 대한 구현은 x 
- 추후에 대댓글이나 댓글도 좋아요 기능 설계 예정

## 2. 게시글 좋아요
- 간단한 게시글 좋아요 기능 구현
- uniqueConstraints 기능을 통해 unique 제약으로 좋아요 관리
- 지금은 DB로 관리 하지만 나중에 Redis를 통해 스케줄링으로 변경할 의향도 있습니다

## 3. 다음 개발 방향
- 우선은 해시태그 개발할 예정
- 해시태그 엔티티랑 게시글 해시태그를 이용해서 만들 예정
- 그리고 시간이 남는다면 현재 엔티티들 관리 메서드 개발 예정