### PR TITLE
feat: Post HashTag 엔티티 작성 및 ErrorCode 살짝 수정

### DIFF
--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/post/Comment.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/post/Comment.java
@@ -56,7 +56,7 @@ public class Comment extends BaseEntity {
 
     private static void validateUserId(Long userId) {
         if (userId == null) {
-            throw new BusinessException(PostErrorCode.POST_USERID_NULL);
+            throw new BusinessException(PostErrorCode.POST_USER_ID_NULL);
         }
     }
 

--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/post/Hashtag.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/post/Hashtag.java
@@ -1,0 +1,68 @@
+package com.prothsync.prothsync.entity.post;
+
+import com.prothsync.prothsync.common.BaseEntity;
+import com.prothsync.prothsync.exception.BusinessException;
+import com.prothsync.prothsync.exception.PostErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.regex.Pattern;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "hashtags")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Hashtag extends BaseEntity {
+
+    private static final int MAX_TAG_LENGTH = 50;
+    private static final Pattern TAG_PATTERN = Pattern.compile("^[가-힣a-zA-Z0-9_]+$");
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long hashtagId;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String tagName;
+
+    private Hashtag(String tagName) {
+        this.tagName = normalizeTagName(tagName);
+    }
+
+    public static Hashtag create(String tagName) {
+        validateTagName(tagName);
+        return new Hashtag(tagName);
+    }
+
+    private static void validateTagName(String tagName) {
+        if (tagName == null || tagName.isBlank()) {
+            throw new BusinessException(PostErrorCode.POST_HASHTAG_NULL);
+        }
+
+        String normalized = normalizeTagName(tagName);
+
+        if (normalized.length() > MAX_TAG_LENGTH) {
+            throw new IllegalArgumentException("해시태그는 " + MAX_TAG_LENGTH + "자를 초과할 수 없습니다.");
+        }
+
+        if (!TAG_PATTERN.matcher(normalized).matches()) {
+            throw new BusinessException(PostErrorCode.HASHTAG_INVALID_PATTERN);
+        }
+    }
+
+    private static String normalizeTagName(String tagName) {
+        return tagName.trim()
+            .replaceAll("^#+", "")
+            .toLowerCase();
+    }
+
+    public String getDisplayName() {
+        return "#" + this.tagName;
+    }
+
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/post/Post.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/post/Post.java
@@ -68,7 +68,7 @@ public class Post extends BaseEntity {
 
     private static void validateUserId(Long userId) {
         if (userId == null) {
-            throw new BusinessException(PostErrorCode.POST_USERID_NULL);
+            throw new BusinessException(PostErrorCode.POST_USER_ID_NULL);
         }
     }
 

--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/post/PostHashtag.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/post/PostHashtag.java
@@ -7,8 +7,8 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Id;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -16,44 +16,37 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Table(
-    name = "post_likes",
+    name = "post_hashtags",
     uniqueConstraints = {
         @UniqueConstraint(
-            name = "uk_post_likes_user_post",
-            columnNames = {"user_id","post_id"}
+            name = "uk_post_hashtags_post_hashtag",
+            columnNames = {"post_id", "hashtag_id"}
         )
     }
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PostLike extends BaseEntity {
+public class PostHashtag  extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long likeId;
-
-    @Column(name = "user_id", nullable = false)
-    private Long userId;
+    private Long postHashtagId;
 
     @Column(name = "post_id", nullable = false)
     private Long postId;
 
-    private PostLike(Long userId, Long postId) {
-        this.userId = userId;
+    @Column(name = "hashtag_id", nullable = false)
+    private Long hashtagId;
+
+    private PostHashtag(Long postId, Long hashtagId) {
         this.postId = postId;
+        this.hashtagId = hashtagId;
     }
-
-    public static PostLike create(Long userId, Long postId) {
-        validateUserId(userId);
+    public static PostHashtag create(Long postId, Long hashtagId) {
         validatePostId(postId);
+        validateHashtagId(hashtagId);
 
-        return new PostLike(userId, postId);
-    }
-
-    private static void validateUserId(Long userId) {
-        if (userId == null) {
-            throw new BusinessException(PostErrorCode.POST_USER_ID_NULL);
-        }
+        return new PostHashtag(postId, hashtagId);
     }
 
     private static void validatePostId(Long postId) {
@@ -62,7 +55,10 @@ public class PostLike extends BaseEntity {
         }
     }
 
-    public boolean isOwnedBy(Long userId) {
-        return this.userId.equals(userId);
+    private static void validateHashtagId(Long hashtagId) {
+        if (hashtagId == null) {
+            throw new BusinessException(PostErrorCode.POST_HASHTAG_ID_NULL);
+        }
     }
+
 }


### PR DESCRIPTION
# 변경사항

## 해시태그 관련 엔티티 작성
- POST 와 HashTag는 N:M 관계로 놓여있다고 생각이 들어 중간에 테이블을 잡아서
- 1:N - M:1 이렇게 구현되도록 하였습니다.
```
Post (1) ──→ (N) PostHashtag (M) ←── (1) Hashtag
         1:N 관계               M:1 관계
```
- 그리고 해시태그 관련해서 정규표현식을 통해서 한글,영어대소문자,숫자,언더스코어 사용하도록 설계 하였습니다.

## 에러코드 명칭 변경
- USERID_NULL -> USER_ID_NULL 이런식으로 ID를 언더스코어로 분리하였습니다.
