### PR TITLE
feat: post 관련 repository 작성

### DIFF
--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/post/Hashtag.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/post/Hashtag.java
@@ -30,6 +30,9 @@ public class Hashtag extends BaseEntity {
     @Column(nullable = false, unique = true, length = 50)
     private String tagName;
 
+    @Column(nullable = false)
+    private int usageCount = 0;
+
     private Hashtag(String tagName) {
         this.tagName = normalizeTagName(tagName);
     }
@@ -63,6 +66,16 @@ public class Hashtag extends BaseEntity {
 
     public String getDisplayName() {
         return "#" + this.tagName;
+    }
+
+    public void incrementUsageCount() {
+        this.usageCount++;
+    }
+
+    public void decrementUsageCount() {
+        if (this.usageCount > 0) {
+            this.usageCount--;
+        }
     }
 
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/CommentRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/CommentRepositoryImpl.java
@@ -1,0 +1,47 @@
+package com.prothsync.prothsync.repository.impl;
+
+import com.prothsync.prothsync.entity.post.Comment;
+import com.prothsync.prothsync.repository.jpa.CommentJpaRepository;
+import com.prothsync.prothsync.repository.repository.CommentRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CommentRepositoryImpl implements CommentRepository {
+
+    private final CommentJpaRepository commentJpaRepository;
+
+    @Override
+    public Comment save(Comment comment) {
+        return commentJpaRepository.save(comment);
+    }
+
+    @Override
+    public Optional<Comment> findById(Long commentId) {
+        return commentJpaRepository.findById(commentId);
+    }
+
+    @Override
+    public Page<Comment> findAllByPostId(Long postId, Pageable pageable) {
+        return commentJpaRepository.findAllByPostId(postId, pageable);
+    }
+
+    @Override
+    public void delete(Comment comment) {
+        commentJpaRepository.delete(comment);
+    }
+
+    @Override
+    public void deleteAllByPostId(Long postId) {
+        commentJpaRepository.deleteAllByPostId(postId);
+    }
+
+    @Override
+    public int countByPostId(Long postId) {
+        return commentJpaRepository.countByPostId(postId);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/HashtagRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/HashtagRepositoryImpl.java
@@ -1,0 +1,46 @@
+package com.prothsync.prothsync.repository.impl;
+
+import com.prothsync.prothsync.entity.post.Hashtag;
+import com.prothsync.prothsync.repository.jpa.HashtagJpaRepository;
+import com.prothsync.prothsync.repository.repository.HashtagRepository;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class HashtagRepositoryImpl implements HashtagRepository {
+
+    private final HashtagJpaRepository hashtagJpaRepository;
+
+    @Override
+    public Hashtag save(Hashtag hashtag) {
+        return hashtagJpaRepository.save(hashtag);
+    }
+
+    @Override
+    public Optional<Hashtag> findById(Long hashtagId) {
+        return hashtagJpaRepository.findById(hashtagId);
+    }
+
+    @Override
+    public Optional<Hashtag> findByTagName(String tagName) {
+        return hashtagJpaRepository.findByTagName(tagName);
+    }
+
+    @Override
+    public List<Hashtag> findAllByTagNameIn(List<String> tagNames) {
+        return hashtagJpaRepository.findAllByTagNameIn(tagNames);
+    }
+
+    @Override
+    public List<Hashtag> findTopByUsageCount(int limit) {
+        return hashtagJpaRepository.findTopByUsageCount(limit);
+    }
+
+    @Override
+    public boolean existsByTagName(String tagName) {
+        return hashtagJpaRepository.existsByTagName(tagName);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/PostHashtagRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/PostHashtagRepositoryImpl.java
@@ -1,0 +1,50 @@
+package com.prothsync.prothsync.repository.impl;
+
+import com.prothsync.prothsync.entity.post.PostHashtag;
+import com.prothsync.prothsync.repository.jpa.PostHashtagJpaRepository;
+import com.prothsync.prothsync.repository.repository.PostHashtagRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PostHashtagRepositoryImpl implements PostHashtagRepository {
+
+    private final PostHashtagJpaRepository postHashtagJpaRepository;
+
+    @Override
+    public PostHashtag save(PostHashtag postHashtag) {
+        return postHashtagJpaRepository.save(postHashtag);
+    }
+
+    @Override
+    public List<PostHashtag> saveAll(List<PostHashtag> postHashtags) {
+        return postHashtagJpaRepository.saveAll(postHashtags);
+    }
+
+    @Override
+    public List<PostHashtag> findAllByPostId(Long postId) {
+        return postHashtagJpaRepository.findAllByPostId(postId);
+    }
+
+    @Override
+    public List<PostHashtag> findAllByHashtagId(Long hashtagId) {
+        return postHashtagJpaRepository.findAllByHashtagId(hashtagId);
+    }
+
+    @Override
+    public void delete(PostHashtag postHashtag) {
+        postHashtagJpaRepository.delete(postHashtag);
+    }
+
+    @Override
+    public void deleteAllByPostId(Long postId) {
+        postHashtagJpaRepository.deleteAllByPostId(postId);
+    }
+
+    @Override
+    public boolean existsByPostIdAndHashtagId(Long postId, Long hashtagId) {
+        return postHashtagJpaRepository.existsByPostIdAndHashtagId(postId, hashtagId);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/PostImageRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/PostImageRepositoryImpl.java
@@ -1,0 +1,56 @@
+package com.prothsync.prothsync.repository.impl;
+
+import com.prothsync.prothsync.entity.post.PostImage;
+import com.prothsync.prothsync.repository.jpa.PostImageJpaRepository;
+import com.prothsync.prothsync.repository.repository.PostImageRepository;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PostImageRepositoryImpl implements PostImageRepository {
+
+    private final PostImageJpaRepository postImageJpaRepository;
+
+    @Override
+    public PostImage save(PostImage postImage) {
+        return postImageJpaRepository.save(postImage);
+    }
+
+    @Override
+    public List<PostImage> saveAll(List<PostImage> postImages) {
+        return postImageJpaRepository.saveAll(postImages);
+    }
+
+    @Override
+    public Optional<PostImage> findById(Long postImageId) {
+        return postImageJpaRepository.findById(postImageId);
+    }
+
+    @Override
+    public List<PostImage> findAllByPostId(Long postId) {
+        return postImageJpaRepository.findAllByPostId(postId);
+    }
+
+    @Override
+    public List<PostImage> findAllByPostIdOrderByDisplayOrder(Long postId) {
+        return postImageJpaRepository.findAllByPostIdOrderByDisplayOrderAsc(postId);
+    }
+
+    @Override
+    public void delete(PostImage postImage) {
+        postImageJpaRepository.delete(postImage);
+    }
+
+    @Override
+    public void deleteAllByPostId(Long postId) {
+        postImageJpaRepository.deleteAllByPostId(postId);
+    }
+
+    @Override
+    public int countByPostId(Long postId) {
+        return postImageJpaRepository.countByPostId(postId);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/PostLikeRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/PostLikeRepositoryImpl.java
@@ -1,0 +1,45 @@
+package com.prothsync.prothsync.repository.impl;
+
+import com.prothsync.prothsync.entity.post.PostLike;
+import com.prothsync.prothsync.repository.jpa.PostLikeJpaRepository;
+import com.prothsync.prothsync.repository.repository.PostLikeRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PostLikeRepositoryImpl implements PostLikeRepository {
+
+    private final PostLikeJpaRepository postLikeJpaRepository;
+
+    @Override
+    public PostLike save(PostLike postLike) {
+        return postLikeJpaRepository.save(postLike);
+    }
+
+    @Override
+    public Optional<PostLike> findByUserIdAndPostId(Long userId, Long postId) {
+        return postLikeJpaRepository.findByUserIdAndPostId(userId, postId);
+    }
+
+    @Override
+    public void delete(PostLike postLike) {
+        postLikeJpaRepository.delete(postLike);
+    }
+
+    @Override
+    public void deleteAllByPostId(Long postId) {
+        postLikeJpaRepository.deleteAllByPostId(postId);
+    }
+
+    @Override
+    public boolean existsByUserIdAndPostId(Long userId, Long postId) {
+        return postLikeJpaRepository.existsByUserIdAndPostId(userId, postId);
+    }
+
+    @Override
+    public int countByPostId(Long postId) {
+        return postLikeJpaRepository.countByPostId(postId);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/PostRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/PostRepositoryImpl.java
@@ -1,0 +1,56 @@
+package com.prothsync.prothsync.repository.impl;
+
+import com.prothsync.prothsync.entity.post.Post;
+import com.prothsync.prothsync.entity.post.PostCategory;
+import com.prothsync.prothsync.entity.post.PostVisibility;
+import com.prothsync.prothsync.repository.jpa.PostJpaRepository;
+import com.prothsync.prothsync.repository.repository.PostRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PostRepositoryImpl implements PostRepository {
+
+    private final PostJpaRepository postJpaRepository;
+
+    @Override
+    public Post save(Post post) {
+        return postJpaRepository.save(post);
+    }
+
+    @Override
+    public Optional<Post> findById(Long postId) {
+        return postJpaRepository.findById(postId);
+    }
+
+    @Override
+    public void delete(Post post) {
+        postJpaRepository.delete(post);
+    }
+
+    @Override
+    public Page<Post> findAllByVisibilityPublic(Pageable pageable) {
+        return postJpaRepository.findAllByVisibility(PostVisibility.PUBLIC, pageable);
+    }
+
+    @Override
+    public Page<Post> findAllByUserId(Long userId, Pageable pageable) {
+        return postJpaRepository.findAllByUserId(userId, pageable);
+    }
+
+    @Override
+    public Page<Post> findAllByCategory(PostCategory category, Pageable pageable) {
+        return postJpaRepository.findAllByCategory(category, pageable);
+    }
+
+    @Override
+    public Page<Post> findAllByUserIdAndVisibilityPublic(Long userId, Pageable pageable) {
+        return postJpaRepository.findAllByUserIdAndVisibility(userId, PostVisibility.PUBLIC, pageable);
+    }
+
+
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/CommentJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/CommentJpaRepository.java
@@ -1,0 +1,15 @@
+package com.prothsync.prothsync.repository.jpa;
+
+import com.prothsync.prothsync.entity.post.Comment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentJpaRepository extends JpaRepository<Comment, Long> {
+
+    Page<Comment> findAllByPostId(Long postId, Pageable pageable);
+
+    void deleteAllByPostId(Long postId);
+
+    int countByPostId(Long postId);
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/HashtagJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/HashtagJpaRepository.java
@@ -1,0 +1,20 @@
+package com.prothsync.prothsync.repository.jpa;
+
+import com.prothsync.prothsync.entity.post.Hashtag;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface HashtagJpaRepository extends JpaRepository<Hashtag, Long> {
+
+    Optional<Hashtag> findByTagName(String tagName);
+
+    List<Hashtag> findAllByTagNameIn(List<String> tagNames);
+
+    boolean existsByTagName(String tagName);
+
+    @Query("SELECT h FROM Hashtag h ORDER BY h.usageCount DESC LIMIT :limit")
+    List<Hashtag> findTopByUsageCount(@Param("limit") int limit);
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/PostHashtagJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/PostHashtagJpaRepository.java
@@ -1,0 +1,16 @@
+package com.prothsync.prothsync.repository.jpa;
+
+import com.prothsync.prothsync.entity.post.PostHashtag;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostHashtagJpaRepository extends JpaRepository<PostHashtag, Long> {
+
+    List<PostHashtag> findAllByPostId(Long postId);
+
+    List<PostHashtag> findAllByHashtagId(Long hashtagId);
+
+    void deleteAllByPostId(Long postId);
+
+    boolean existsByPostIdAndHashtagId(Long postId, Long hashtagId);
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/PostImageJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/PostImageJpaRepository.java
@@ -1,0 +1,16 @@
+package com.prothsync.prothsync.repository.jpa;
+
+import com.prothsync.prothsync.entity.post.PostImage;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostImageJpaRepository extends JpaRepository<PostImage, Long> {
+
+    List<PostImage> findAllByPostId(Long postId);
+
+    List<PostImage> findAllByPostIdOrderByDisplayOrderAsc(Long postId);
+
+    void deleteAllByPostId(Long postId);
+
+    int countByPostId(Long postId);
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/PostJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/PostJpaRepository.java
@@ -1,0 +1,19 @@
+package com.prothsync.prothsync.repository.jpa;
+
+import com.prothsync.prothsync.entity.post.Post;
+import com.prothsync.prothsync.entity.post.PostCategory;
+import com.prothsync.prothsync.entity.post.PostVisibility;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostJpaRepository extends JpaRepository<Post, Long> {
+    Page<Post> findAllByVisibility(PostVisibility visibility, Pageable pageable);
+
+    Page<Post> findAllByUserId(Long userId, Pageable pageable);
+
+    Page<Post> findAllByCategory(PostCategory category, Pageable pageable);
+
+    Page<Post> findAllByUserIdAndVisibility(Long userId, PostVisibility visibility, Pageable pageable);
+
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/PostLikeJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/PostLikeJpaRepository.java
@@ -1,0 +1,16 @@
+package com.prothsync.prothsync.repository.jpa;
+
+import com.prothsync.prothsync.entity.post.PostLike;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostLikeJpaRepository extends JpaRepository<PostLike, Long> {
+
+    Optional<PostLike> findByUserIdAndPostId(Long userId, Long postId);
+
+    void deleteAllByPostId(Long postId);
+
+    boolean existsByUserIdAndPostId(Long userId, Long postId);
+
+    int countByPostId(Long postId);
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/CommentRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/CommentRepository.java
@@ -1,0 +1,21 @@
+package com.prothsync.prothsync.repository.repository;
+
+import com.prothsync.prothsync.entity.post.Comment;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CommentRepository {
+
+    Comment save(Comment comment);
+
+    Optional<Comment> findById(Long commentId);
+
+    Page<Comment> findAllByPostId(Long postId, Pageable pageable);
+
+    void delete(Comment comment);
+
+    void deleteAllByPostId(Long postId);
+
+    int countByPostId(Long postId);
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/HashtagRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/HashtagRepository.java
@@ -1,0 +1,20 @@
+package com.prothsync.prothsync.repository.repository;
+
+import com.prothsync.prothsync.entity.post.Hashtag;
+import java.util.List;
+import java.util.Optional;
+
+public interface HashtagRepository {
+
+    Hashtag save(Hashtag hashtag);
+
+    Optional<Hashtag> findById(Long hashtagId);
+
+    Optional<Hashtag> findByTagName(String tagName);
+
+    List<Hashtag> findAllByTagNameIn(List<String> tagNames);
+
+    List<Hashtag> findTopByUsageCount(int limit);
+
+    boolean existsByTagName(String tagName);
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/PostHashtagRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/PostHashtagRepository.java
@@ -1,0 +1,21 @@
+package com.prothsync.prothsync.repository.repository;
+
+import com.prothsync.prothsync.entity.post.PostHashtag;
+import java.util.List;
+
+public interface PostHashtagRepository {
+
+    PostHashtag save(PostHashtag postHashtag);
+
+    List<PostHashtag> saveAll(List<PostHashtag> postHashtags);
+
+    List<PostHashtag> findAllByPostId(Long postId);
+
+    List<PostHashtag> findAllByHashtagId(Long hashtagId);
+
+    void delete(PostHashtag postHashtag);
+
+    void deleteAllByPostId(Long postId);
+
+    boolean existsByPostIdAndHashtagId(Long postId, Long hashtagId);
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/PostImageRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/PostImageRepository.java
@@ -1,0 +1,24 @@
+package com.prothsync.prothsync.repository.repository;
+
+import com.prothsync.prothsync.entity.post.PostImage;
+import java.util.List;
+import java.util.Optional;
+
+public interface PostImageRepository {
+
+    PostImage save(PostImage postImage);
+
+    List<PostImage> saveAll(List<PostImage> postImages);
+
+    Optional<PostImage> findById(Long postImageId);
+
+    List<PostImage> findAllByPostId(Long postId);
+
+    List<PostImage> findAllByPostIdOrderByDisplayOrder(Long postId);
+
+    void delete(PostImage postImage);
+
+    void deleteAllByPostId(Long postId);
+
+    int countByPostId(Long postId);
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/PostLikeRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/PostLikeRepository.java
@@ -1,0 +1,19 @@
+package com.prothsync.prothsync.repository.repository;
+
+import com.prothsync.prothsync.entity.post.PostLike;
+import java.util.Optional;
+
+public interface PostLikeRepository {
+
+    PostLike save(PostLike postLike);
+
+    Optional<PostLike> findByUserIdAndPostId(Long userId, Long postId);
+
+    void delete(PostLike postLike);
+
+    void deleteAllByPostId(Long postId);
+
+    boolean existsByUserIdAndPostId(Long userId, Long postId);
+
+    int countByPostId(Long postId);
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/PostRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/PostRepository.java
@@ -1,0 +1,23 @@
+package com.prothsync.prothsync.repository.repository;
+
+import com.prothsync.prothsync.entity.post.Post;
+import com.prothsync.prothsync.entity.post.PostCategory;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface PostRepository {
+
+    Post save(Post post);
+    Optional<Post> findById(Long postId);
+    void delete(Post post);
+    Page<Post> findAllByVisibilityPublic(Pageable pageable);
+
+    Page<Post> findAllByUserId(Long userId, Pageable pageable);
+
+    Page<Post> findAllByCategory(PostCategory category, Pageable pageable);
+
+    Page<Post> findAllByUserIdAndVisibilityPublic(Long userId, Pageable pageable);
+
+
+}


### PR DESCRIPTION
# 변경사항
- Post 관련 엔티티들의 Repository 레이어를 구현했습니다.
- Post, PostImage, Comment, PostLike, Hashtag, PostHashtag Repository 추가
- JpaRepository → Interface → Impl 3계층 구조 적용

## 추상화 레이어 도입 이유
- 필요한 메서드만 노출하여 의도치 않은 사용 방지
- 저장소 구현체 변경 시 Service 레이어 수정 최소화
- 테스트 시 Mock 주입 용이