### PR TITLE
feat: post 관련 Controller 작성

### DIFF
--- a/prothsync/src/main/java/com/prothsync/prothsync/config/SecurityConfig.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.prothsync.prothsync.security.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -38,8 +39,18 @@ public class SecurityConfig {
                 .authenticationEntryPoint(jwtAuthenticationEntryPoint)
             )
             .authorizeHttpRequests(auth -> auth
+                // Auth
                 .requestMatchers("/api/auth/signup", "/api/auth/login", "/api/auth/refresh").permitAll()
+                // Swagger
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                // Posts - 공개 조회
+                .requestMatchers(HttpMethod.GET, "/api/posts").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/posts/category/**").permitAll()
+                // Comments - 공개 조회
+                .requestMatchers(HttpMethod.GET, "/api/posts/*/comments").permitAll()
+                // Hashtags - 공개 조회
+                .requestMatchers(HttpMethod.GET, "/api/hashtags/**").permitAll()
+                // 나머지는 인증 필요
                 .anyRequest().authenticated()
             )
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/prothsync/src/main/java/com/prothsync/prothsync/config/WebMvcConfig.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/config/WebMvcConfig.java
@@ -1,0 +1,20 @@
+package com.prothsync.prothsync.config;
+
+import com.prothsync.prothsync.global.PageableArgumentResolver;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final PageableArgumentResolver pageableArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(pageableArgumentResolver);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/CommentController.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/CommentController.java
@@ -1,0 +1,71 @@
+package com.prothsync.prothsync.controller;
+
+import com.prothsync.prothsync.controller.docs.CommentControllerDocs;
+import com.prothsync.prothsync.dto.CommentCreateRequestDTO;
+import com.prothsync.prothsync.dto.CommentResponseDTO;
+import com.prothsync.prothsync.dto.CommentUpdateRequestDTO;
+import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.security.CustomUserDetails;
+import com.prothsync.prothsync.service.CommentService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class CommentController implements CommentControllerDocs {
+
+    private final CommentService commentService;
+
+    @PostMapping("/posts/{postId}/comments")
+    public ResponseEntity<CommentResponseDTO> createComment(
+        @PathVariable Long postId,
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        @Valid @RequestBody CommentCreateRequestDTO request
+    ) {
+        CommentResponseDTO response = commentService.createComment(
+            postId, userDetails.getUserId(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping("/posts/{postId}/comments")
+    public ResponseEntity<PageResponse<CommentResponseDTO>> getComments(
+        @PathVariable Long postId,
+        Pageable pageable
+    ) {
+        PageResponse<CommentResponseDTO> response = commentService.getComments(postId, pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/comments/{commentId}")
+    public ResponseEntity<CommentResponseDTO> updateComment(
+        @PathVariable Long commentId,
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        @Valid @RequestBody CommentUpdateRequestDTO request
+    ) {
+        CommentResponseDTO response = commentService.updateComment(
+            commentId, userDetails.getUserId(), request);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/comments/{commentId}")
+    public ResponseEntity<Void> deleteComment(
+        @PathVariable Long commentId,
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        commentService.deleteComment(commentId, userDetails.getUserId());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/HashtagController.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/HashtagController.java
@@ -1,0 +1,28 @@
+package com.prothsync.prothsync.controller;
+
+import com.prothsync.prothsync.controller.docs.HashtagControllerDocs;
+import com.prothsync.prothsync.dto.HashtagResponseDTO;
+import com.prothsync.prothsync.service.HashtagService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/hashtags")
+public class HashtagController implements HashtagControllerDocs {
+
+    private final HashtagService hashtagService;
+
+    @GetMapping("/trending")
+    public ResponseEntity<List<HashtagResponseDTO>> getTrendingHashtags(
+        @RequestParam(defaultValue = "10") int limit
+    ) {
+        List<HashtagResponseDTO> response = hashtagService.getTrendingHashtags(limit);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/LikeController.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/LikeController.java
@@ -1,0 +1,40 @@
+package com.prothsync.prothsync.controller;
+
+import com.prothsync.prothsync.controller.docs.LikeControllerDocs;
+import com.prothsync.prothsync.dto.LikeResponseDTO;
+import com.prothsync.prothsync.security.CustomUserDetails;
+import com.prothsync.prothsync.service.LikeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/posts/{postId}/likes")
+public class LikeController implements LikeControllerDocs {
+
+    private final LikeService likeService;
+
+    @PostMapping
+    public ResponseEntity<LikeResponseDTO> toggleLike(
+        @PathVariable Long postId,
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        LikeResponseDTO response = likeService.toggleLike(postId, userDetails.getUserId());
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<Boolean> isLiked(
+        @PathVariable Long postId,
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        boolean liked = likeService.isLiked(postId, userDetails.getUserId());
+        return ResponseEntity.ok(liked);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/PostController.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/PostController.java
@@ -1,0 +1,98 @@
+package com.prothsync.prothsync.controller;
+
+import com.prothsync.prothsync.dto.PostCreateRequestDTO;
+import com.prothsync.prothsync.dto.PostResponseDTO;
+import com.prothsync.prothsync.dto.PostSummaryResponseDTO;
+import com.prothsync.prothsync.dto.PostUpdateRequestDTO;
+import com.prothsync.prothsync.entity.post.PostCategory;
+import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.security.CustomUserDetails;
+import com.prothsync.prothsync.service.PostService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/posts")
+public class PostController {
+
+    private final PostService postService;
+
+    @PostMapping
+    public ResponseEntity<PostResponseDTO> createPost(
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        @Valid @RequestBody PostCreateRequestDTO request
+    ){
+        PostResponseDTO response = postService.createPost(userDetails.getUserId(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping("/{postId}")
+    public ResponseEntity<PostResponseDTO> getPost(
+        @PathVariable Long postId,
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        PostResponseDTO response = postService.getPost(postId, userDetails.getUserId());
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<PageResponse<PostSummaryResponseDTO>> getPublicPosts(Pageable pageable) {
+        PageResponse<PostSummaryResponseDTO> response = postService.getPublicPosts(pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/users/{userId}")
+    public ResponseEntity<PageResponse<PostSummaryResponseDTO>> getUserPosts(
+        @PathVariable Long userId,
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        Pageable pageable
+    ) {
+        PageResponse<PostSummaryResponseDTO> response = postService.getUserPosts(
+            userId, userDetails.getUserId(), pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/category/{category}")
+    public ResponseEntity<PageResponse<PostSummaryResponseDTO>> getPostsByCategory(
+        @PathVariable PostCategory category,
+        Pageable pageable
+    ) {
+        PageResponse<PostSummaryResponseDTO> response = postService.getPostsByCategory(
+            category, pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{postId}")
+    public ResponseEntity<PostResponseDTO> updatePost(
+        @PathVariable Long postId,
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        @Valid @RequestBody PostUpdateRequestDTO request
+    ) {
+        PostResponseDTO response = postService.updatePost(
+            postId, userDetails.getUserId(), request);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<Void> deletePost(
+        @PathVariable Long postId,
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        postService.deletePost(postId, userDetails.getUserId());
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/CommentControllerDocs.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/CommentControllerDocs.java
@@ -1,0 +1,109 @@
+package com.prothsync.prothsync.controller.docs;
+
+import com.prothsync.prothsync.dto.CommentCreateRequestDTO;
+import com.prothsync.prothsync.dto.CommentResponseDTO;
+import com.prothsync.prothsync.dto.CommentUpdateRequestDTO;
+import com.prothsync.prothsync.exception.ErrorResponse;
+import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "댓글", description = "댓글 CRUD API")
+@SecurityRequirement(name = "bearerAuth")
+public interface CommentControllerDocs {
+
+    @Operation(summary = "댓글 작성", description = "게시글에 댓글을 작성합니다.")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "201",
+            description = "댓글 작성 성공",
+            content = @Content(schema = @Schema(implementation = CommentResponseDTO.class))
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "유효성 검증 실패",
+            content = @Content(schema = @Schema(implementation = String.class))
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "게시글을 찾을 수 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<CommentResponseDTO> createComment(
+        @Parameter(description = "게시글 ID") Long postId,
+        CustomUserDetails userDetails,
+        CommentCreateRequestDTO request
+    );
+
+    @Operation(summary = "댓글 목록 조회", description = "게시글의 댓글을 페이징하여 조회합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공"),
+        @ApiResponse(
+            responseCode = "404",
+            description = "게시글을 찾을 수 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<PageResponse<CommentResponseDTO>> getComments(
+        @Parameter(description = "게시글 ID") Long postId,
+        Pageable pageable
+    );
+
+    @Operation(summary = "댓글 수정", description = "본인이 작성한 댓글을 수정합니다.")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "댓글 수정 성공",
+            content = @Content(schema = @Schema(implementation = CommentResponseDTO.class))
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "유효성 검증 실패",
+            content = @Content(schema = @Schema(implementation = String.class))
+        ),
+        @ApiResponse(
+            responseCode = "403",
+            description = "접근 권한 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "댓글을 찾을 수 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<CommentResponseDTO> updateComment(
+        @Parameter(description = "댓글 ID") Long commentId,
+        CustomUserDetails userDetails,
+        CommentUpdateRequestDTO request
+    );
+
+    @Operation(summary = "댓글 삭제", description = "본인이 작성한 댓글을 삭제합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "댓글 삭제 성공"),
+        @ApiResponse(
+            responseCode = "403",
+            description = "접근 권한 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "댓글을 찾을 수 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<Void> deleteComment(
+        @Parameter(description = "댓글 ID") Long commentId,
+        CustomUserDetails userDetails
+    );
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/HashtagControllerDocs.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/HashtagControllerDocs.java
@@ -1,0 +1,22 @@
+package com.prothsync.prothsync.controller.docs;
+
+import com.prothsync.prothsync.dto.HashtagResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "해시태그", description = "해시태그 조회 API")
+public interface HashtagControllerDocs {
+
+    @Operation(summary = "인기 해시태그 조회", description = "사용량 기준 상위 해시태그를 조회합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    ResponseEntity<List<HashtagResponseDTO>> getTrendingHashtags(
+        @Parameter(description = "조회 개수 (기본값: 10)") int limit
+    );
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/LikeControllerDocs.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/LikeControllerDocs.java
@@ -1,0 +1,51 @@
+package com.prothsync.prothsync.controller.docs;
+
+import com.prothsync.prothsync.dto.LikeResponseDTO;
+import com.prothsync.prothsync.exception.ErrorResponse;
+import com.prothsync.prothsync.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "좋아요", description = "게시글 좋아요 API")
+@SecurityRequirement(name = "bearerAuth")
+public interface LikeControllerDocs {
+
+    @Operation(summary = "좋아요 토글", description = "게시글에 좋아요를 누르거나 취소합니다.")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "좋아요 토글 성공",
+            content = @Content(schema = @Schema(implementation = LikeResponseDTO.class))
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description = "인증 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "게시글을 찾을 수 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<LikeResponseDTO> toggleLike(
+        @Parameter(description = "게시글 ID") Long postId,
+        CustomUserDetails userDetails
+    );
+
+    @Operation(summary = "좋아요 여부 확인", description = "현재 사용자가 해당 게시글에 좋아요를 눌렀는지 확인합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    ResponseEntity<Boolean> isLiked(
+        @Parameter(description = "게시글 ID") Long postId,
+        CustomUserDetails userDetails
+    );
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/PostControllerDocs.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/PostControllerDocs.java
@@ -1,0 +1,149 @@
+package com.prothsync.prothsync.controller.docs;
+
+import com.prothsync.prothsync.dto.PostCreateRequestDTO;
+import com.prothsync.prothsync.dto.PostResponseDTO;
+import com.prothsync.prothsync.dto.PostSummaryResponseDTO;
+import com.prothsync.prothsync.dto.PostUpdateRequestDTO;
+import com.prothsync.prothsync.entity.post.PostCategory;
+import com.prothsync.prothsync.exception.ErrorResponse;
+import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "게시글", description = "게시글 CRUD API")
+@SecurityRequirement(name = "bearerAuth")
+public interface PostControllerDocs {
+
+    @Operation(summary = "게시글 작성", description = "새로운 게시글을 작성합니다.")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "201",
+            description = "게시글 작성 성공",
+            content = @Content(schema = @Schema(implementation = PostResponseDTO.class))
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "유효성 검증 실패",
+            content = @Content(schema = @Schema(implementation = String.class))
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description = "인증 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<PostResponseDTO> createPost(
+        CustomUserDetails userDetails,
+        PostCreateRequestDTO request
+    );
+
+    @Operation(summary = "게시글 단건 조회", description = "게시글 ID로 단건 조회합니다. 비공개 게시글은 작성자만 조회 가능합니다.")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "게시글 조회 성공",
+            content = @Content(schema = @Schema(implementation = PostResponseDTO.class))
+        ),
+        @ApiResponse(
+            responseCode = "403",
+            description = "접근 권한 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "게시글을 찾을 수 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<PostResponseDTO> getPost(
+        @Parameter(description = "게시글 ID") Long postId,
+        CustomUserDetails userDetails
+    );
+
+    @Operation(summary = "전체 공개 게시글 목록 조회", description = "공개 게시글을 페이징하여 조회합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    ResponseEntity<PageResponse<PostSummaryResponseDTO>> getPublicPosts(Pageable pageable);
+
+    @Operation(summary = "사용자별 게시글 목록 조회", description = "특정 사용자의 게시글을 조회합니다. 본인이면 전체, 타인이면 공개 게시글만 조회됩니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공"),
+        @ApiResponse(
+            responseCode = "404",
+            description = "사용자를 찾을 수 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<PageResponse<PostSummaryResponseDTO>> getUserPosts(
+        @Parameter(description = "대상 사용자 ID") Long userId,
+        CustomUserDetails userDetails,
+        Pageable pageable
+    );
+
+    @Operation(summary = "카테고리별 게시글 목록 조회", description = "카테고리로 게시글을 필터링하여 조회합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    ResponseEntity<PageResponse<PostSummaryResponseDTO>> getPostsByCategory(
+        @Parameter(description = "카테고리") PostCategory category,
+        Pageable pageable
+    );
+
+    @Operation(summary = "게시글 수정", description = "본인이 작성한 게시글을 수정합니다.")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "게시글 수정 성공",
+            content = @Content(schema = @Schema(implementation = PostResponseDTO.class))
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "유효성 검증 실패",
+            content = @Content(schema = @Schema(implementation = String.class))
+        ),
+        @ApiResponse(
+            responseCode = "403",
+            description = "접근 권한 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "게시글을 찾을 수 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<PostResponseDTO> updatePost(
+        @Parameter(description = "게시글 ID") Long postId,
+        CustomUserDetails userDetails,
+        PostUpdateRequestDTO request
+    );
+
+    @Operation(summary = "게시글 삭제", description = "본인이 작성한 게시글을 삭제합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "게시글 삭제 성공"),
+        @ApiResponse(
+            responseCode = "403",
+            description = "접근 권한 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "게시글을 찾을 수 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<Void> deletePost(
+        @Parameter(description = "게시글 ID") Long postId,
+        CustomUserDetails userDetails
+    );
+}


### PR DESCRIPTION
# 변경사항

## Controller 작성
- swagger로 인해서 코드가 복잡해지는 것을 피하기 위해 swagger 관련해서는 interface로 만든다음 상속 받도록 하였습니다.

## SecurityConfig
- 새로 만든 controller의 api를 추가하였습니다.

## WebMvcConfig
-  커스텀 PageableArgumentResolver 등록 (이게 없으면 Pageable 파라미터 바인딩이 기본 Spring 방식으로 동작해서 커스텀 size 제한이 적용 안 됨)