### PR TITLE
feat: 팔로우 기능 구현

### DIFF
--- a/prothsync/src/main/java/com/prothsync/prothsync/config/SecurityConfig.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/config/SecurityConfig.java
@@ -50,6 +50,9 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/api/posts/*/comments").permitAll()
                 // Hashtags - 공개 조회
                 .requestMatchers(HttpMethod.GET, "/api/hashtags/**").permitAll()
+                // Follow - 공개 조회
+                .requestMatchers(HttpMethod.GET, "/api/users/*/follow/followers").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/users/*/follow/followings").permitAll()
                 // 나머지는 인증 필요
                 .anyRequest().authenticated()
             )

--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/FollowController.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/FollowController.java
@@ -1,0 +1,65 @@
+package com.prothsync.prothsync.controller;
+
+import com.prothsync.prothsync.controller.docs.FollowControllerDocs;
+import com.prothsync.prothsync.dto.FollowResponseDTO;
+import com.prothsync.prothsync.dto.FollowUserResponseDTO;
+import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.security.CustomUserDetails;
+import com.prothsync.prothsync.service.FollowService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users/{userId}/follow")
+public class FollowController implements FollowControllerDocs {
+
+    private final FollowService followService;
+
+    @PostMapping
+    public ResponseEntity<FollowResponseDTO> toggleFollow(
+        @PathVariable Long userId,
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        FollowResponseDTO response = followService.toggleFollow(
+            userDetails.getUserId(), userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/status")
+    public ResponseEntity<Boolean> isFollowing(
+        @PathVariable Long userId,
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        boolean following = followService.isFollowing(
+            userDetails.getUserId(), userId);
+        return ResponseEntity.ok(following);
+    }
+
+    @GetMapping("/followers")
+    public ResponseEntity<PageResponse<FollowUserResponseDTO>> getFollowers(
+        @PathVariable Long userId,
+        Pageable pageable
+    ) {
+        PageResponse<FollowUserResponseDTO> response = followService.getFollowers(
+            userId, pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/followings")
+    public ResponseEntity<PageResponse<FollowUserResponseDTO>> getFollowings(
+        @PathVariable Long userId,
+        Pageable pageable
+    ) {
+        PageResponse<FollowUserResponseDTO> response = followService.getFollowings(
+            userId, pageable);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/PostController.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/PostController.java
@@ -1,5 +1,6 @@
 package com.prothsync.prothsync.controller;
 
+import com.prothsync.prothsync.controller.docs.PostControllerDocs;
 import com.prothsync.prothsync.dto.PostCreateRequestDTO;
 import com.prothsync.prothsync.dto.PostResponseDTO;
 import com.prothsync.prothsync.dto.PostSummaryResponseDTO;
@@ -26,7 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/posts")
-public class PostController {
+public class PostController implements PostControllerDocs {
 
     private final PostService postService;
 

--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/FollowControllerDocs.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/FollowControllerDocs.java
@@ -1,0 +1,87 @@
+package com.prothsync.prothsync.controller.docs;
+
+import com.prothsync.prothsync.dto.FollowResponseDTO;
+import com.prothsync.prothsync.dto.FollowUserResponseDTO;
+import com.prothsync.prothsync.exception.ErrorResponse;
+import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "팔로우", description = "팔로우 API")
+@SecurityRequirement(name = "bearerAuth")
+public interface FollowControllerDocs {
+
+    @Operation(summary = "팔로우 토글", description = "대상 사용자를 팔로우하거나 언팔로우합니다.")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "팔로우 토글 성공",
+            content = @Content(schema = @Schema(implementation = FollowResponseDTO.class))
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "자기 자신을 팔로우할 수 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description = "인증 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "사용자를 찾을 수 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<FollowResponseDTO> toggleFollow(
+        @Parameter(description = "대상 사용자 ID") Long userId,
+        CustomUserDetails userDetails
+    );
+
+    @Operation(summary = "팔로우 여부 확인", description = "현재 사용자가 대상 사용자를 팔로우하고 있는지 확인합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    ResponseEntity<Boolean> isFollowing(
+        @Parameter(description = "대상 사용자 ID") Long userId,
+        CustomUserDetails userDetails
+    );
+
+    @Operation(summary = "팔로워 목록 조회", description = "대상 사용자의 팔로워 목록을 페이징하여 조회합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공"),
+        @ApiResponse(
+            responseCode = "404",
+            description = "사용자를 찾을 수 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<PageResponse<FollowUserResponseDTO>> getFollowers(
+        @Parameter(description = "대상 사용자 ID") Long userId,
+        Pageable pageable
+    );
+
+    @Operation(summary = "팔로잉 목록 조회", description = "대상 사용자의 팔로잉 목록을 페이징하여 조회합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공"),
+        @ApiResponse(
+            responseCode = "404",
+            description = "사용자를 찾을 수 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<PageResponse<FollowUserResponseDTO>> getFollowings(
+        @Parameter(description = "대상 사용자 ID") Long userId,
+        Pageable pageable
+    );
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/dto/FollowResponseDTO.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/dto/FollowResponseDTO.java
@@ -1,0 +1,12 @@
+package com.prothsync.prothsync.dto;
+
+public record FollowResponseDTO(
+    Long targetUserId,
+    boolean followed,
+    int followerCount
+) {
+
+    public static FollowResponseDTO of(Long targetUserId, boolean followed, int followerCount) {
+        return new FollowResponseDTO(targetUserId, followed, followerCount);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/dto/FollowUserResponseDTO.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/dto/FollowUserResponseDTO.java
@@ -1,0 +1,19 @@
+package com.prothsync.prothsync.dto;
+
+import com.prothsync.prothsync.entity.user.User;
+import com.prothsync.prothsync.entity.user.UserType;
+
+public record FollowUserResponseDTO(
+    Long userId,
+    String nickName,
+    UserType userType
+) {
+
+    public static FollowUserResponseDTO from(User user) {
+        return new FollowUserResponseDTO(
+            user.getUserId(),
+            user.getNickName(),
+            user.getUserType()
+        );
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/user/Follow.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/user/Follow.java
@@ -1,0 +1,70 @@
+package com.prothsync.prothsync.entity.user;
+
+import com.prothsync.prothsync.common.BaseEntity;
+import com.prothsync.prothsync.exception.BusinessException;
+import com.prothsync.prothsync.exception.FollowErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Table;
+import jakarta.persistence.Id;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+    name = "follows",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_follows_follower_following",
+            columnNames = {"follower_id", "following_id"}
+        )
+    }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Follow  extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long followId;
+
+    @Column(name = "follower_id", nullable = false)
+    private Long followerId;
+
+    @Column(name = "following_id", nullable = false)
+    private Long followingId;
+
+    private Follow(Long followerId, Long followingId) {
+        this.followerId = followerId;
+        this.followingId = followingId;
+    }
+
+    public static Follow create(Long followerId, Long followingId) {
+        validateFollowerId(followerId);
+        validateFollowingId(followingId);
+        validateNotSelf(followerId, followingId);
+
+        return new Follow(followerId, followingId);
+    }
+
+    private static void validateFollowerId(Long followerId) {
+        if (followerId == null) {
+            throw new BusinessException(FollowErrorCode.FOLLOWER_ID_NULL);
+        }
+    }
+
+    private static void validateFollowingId(Long followingId) {
+        if (followingId == null) {
+            throw new BusinessException(FollowErrorCode.FOLLOWING_ID_NULL);
+        }
+    }
+
+    private static void validateNotSelf(Long followerId, Long followingId) {
+        if (followerId.equals(followingId)) {
+            throw new BusinessException(FollowErrorCode.CANNOT_FOLLOW_SELF);
+        }
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/user/User.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/user/User.java
@@ -56,6 +56,12 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private UserRole userRole;
 
+    @Column(nullable = false)
+    private int followerCount = 0;
+
+    @Column(nullable = false)
+    private int followingCount = 0;
+
     private User(String userName,
         String password,
         String nickName,
@@ -170,6 +176,26 @@ public class User extends BaseEntity {
     public void updateEmail(String newEmail) {
         validateEmail(newEmail);
         this.email = newEmail;
+    }
+
+    public void incrementFollowerCount() {
+        this.followerCount++;
+    }
+
+    public void decrementFollowerCount() {
+        if (this.followerCount > 0) {
+            this.followerCount--;
+        }
+    }
+
+    public void incrementFollowingCount() {
+        this.followingCount++;
+    }
+
+    public void decrementFollowingCount() {
+        if (this.followingCount > 0) {
+            this.followingCount--;
+        }
     }
 
     public void promoteToAdmin() {

--- a/prothsync/src/main/java/com/prothsync/prothsync/exception/FollowErrorCode.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/exception/FollowErrorCode.java
@@ -1,0 +1,19 @@
+package com.prothsync.prothsync.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum FollowErrorCode implements ErrorCode {
+
+    FOLLOWER_ID_NULL(HttpStatus.BAD_REQUEST, "팔로워 ID가 NULL 입니다."),
+    FOLLOWING_ID_NULL(HttpStatus.BAD_REQUEST, "팔로잉 ID가 NULL 입니다."),
+    CANNOT_FOLLOW_SELF(HttpStatus.BAD_REQUEST, "자기 자신을 팔로우할 수 없습니다."),
+    FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, "팔로우 정보를 찾을 수 없습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/exception/PostErrorCode.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/exception/PostErrorCode.java
@@ -1,0 +1,54 @@
+package com.prothsync.prothsync.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PostErrorCode implements ErrorCode {
+
+    POST_USER_ID_NULL(HttpStatus.NOT_FOUND, "사용자 ID가 NULL 입니다."),
+    POST_CATEGORY_NULL(HttpStatus.NOT_FOUND, "카테고리가 NULL 입니다."),
+    POST_VISIBILITY_NULL(HttpStatus.NOT_FOUND, "공개범위가 NULL 입니다."),
+    POST_ID_NULL(HttpStatus.NOT_FOUND, "게시글 ID가 NULL 입니다."),
+    POST_CONTENT_NULL(HttpStatus.NOT_FOUND, "댓글 내용이 NULL 입니다."),
+    POST_HASHTAG_ID_NULL(HttpStatus.NOT_FOUND, "해시태그 ID가 NULL 입니다."),
+    POST_HASHTAG_NULL(HttpStatus.NOT_FOUND, "해시태그 이름이 NULL 입니다."),
+
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."),
+    POST_ACCESS_DENIED(HttpStatus.FORBIDDEN, "게시글에 접근할 권한이 없습니다."),
+    POST_CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "게시글 내용이 너무 깁니다.(최대 2000자)"),
+    POST_CATEGORY_REQUIRED(HttpStatus.BAD_REQUEST, "카테고리는 필수입니다."),
+    POST_VISIBILITY_REQUIRED(HttpStatus.BAD_REQUEST, "공개 범위는 필수입니다."),
+
+    IMAGE_PATH_NULL(HttpStatus.NOT_FOUND, "이미지 경로가 NULL 입니다."),
+    IMAGE_ORIGINAL_NAME_NULL(HttpStatus.NOT_FOUND, "이미지 원본 이름이 NULL 입니다."),
+    IMAGE_STORED_NAME_NULL(HttpStatus.NOT_FOUND, "이미지 저장 이름이 NULL 입니다."),
+    IMAGE_DISPLAY_ORDER_INVALID(HttpStatus.NOT_FOUND, "이미지 순서는 0 이상이어야 합니다."),
+    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "이미지를 찾을 수 없습니다."),
+    IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패했습니다."),
+    IMAGE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 삭제에 실패했습니다."),
+    IMAGE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "게시글당 이미지는 최대 10개까지 등록 가능합니다."),
+    INVALID_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "이미지 파일만 업로드 가능합니다."),
+    IMAGE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "이미지 파일 크기가 너무 큽니다."),
+
+    ALREADY_LIKED(HttpStatus.CONFLICT, "이미 좋아요를 눌렀습니다."),
+    LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "좋아요 정보를 찾을 수 없습니다."),
+
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
+    COMMENT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "댓글에 접근할 권한이 없습니다."),
+    COMMENT_CONTENT_REQUIRED(HttpStatus.BAD_REQUEST, "댓글 내용은 필수입니다."),
+    COMMENT_CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "댓글 내용이 너무 깁니다.(최대 500자)"),
+    REPLY_DEPTH_EXCEEDED(HttpStatus.BAD_REQUEST, "대댓글에는 답글을 달 수 없습니다."),
+
+    HASHTAG_NOT_FOUND(HttpStatus.NOT_FOUND, "해시태그를 찾을 수 없습니다."),
+    HASHTAG_INVALID_FORMAT(HttpStatus.BAD_REQUEST, "해시태그 형식이 올바르지 않습니다."),
+    HASHTAG_INVALID_PATTERN(HttpStatus.BAD_REQUEST, "해시태그는 한글, 영문, 숫자, 밑줄(_)만 사용 가능합니다."),
+    HASHTAG_TOO_LONG(HttpStatus.BAD_REQUEST, "해시태그가 너무 깁니다.(최대 50자)"),
+    HASHTAG_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "게시글당 해시태그는 최대 30개까지 등록 가능합니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/FollowRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/FollowRepositoryImpl.java
@@ -1,0 +1,57 @@
+package com.prothsync.prothsync.repository.impl;
+
+import com.prothsync.prothsync.entity.user.Follow;
+import com.prothsync.prothsync.repository.jpa.FollowJpaRepository;
+import com.prothsync.prothsync.repository.repository.FollowRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class FollowRepositoryImpl implements FollowRepository {
+
+    private final FollowJpaRepository followJpaRepository;
+
+    @Override
+    public Follow save(Follow follow) {
+        return followJpaRepository.save(follow);
+    }
+
+    @Override
+    public Optional<Follow> findByFollowerIdAndFollowingId(Long followerId, Long followingId) {
+        return followJpaRepository.findByFollowerIdAndFollowingId(followerId, followingId);
+    }
+
+    @Override
+    public boolean existsByFollowerIdAndFollowingId(Long followerId, Long followingId) {
+        return followJpaRepository.existsByFollowerIdAndFollowingId(followerId, followingId);
+    }
+
+    @Override
+    public Page<Follow> findAllByFollowingId(Long followingId, Pageable pageable) {
+        return followJpaRepository.findAllByFollowingId(followingId, pageable);
+    }
+
+    @Override
+    public Page<Follow> findAllByFollowerId(Long followerId, Pageable pageable) {
+        return followJpaRepository.findAllByFollowerId(followerId, pageable);
+    }
+
+    @Override
+    public void delete(Follow follow) {
+        followJpaRepository.delete(follow);
+    }
+
+    @Override
+    public int countByFollowingId(Long followingId) {
+        return followJpaRepository.countByFollowingId(followingId);
+    }
+
+    @Override
+    public int countByFollowerId(Long followerId) {
+        return followJpaRepository.countByFollowerId(followerId);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/FollowJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/FollowJpaRepository.java
@@ -1,0 +1,22 @@
+package com.prothsync.prothsync.repository.jpa;
+
+import com.prothsync.prothsync.entity.user.Follow;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FollowJpaRepository extends JpaRepository<Follow, Long> {
+
+    Optional<Follow> findByFollowerIdAndFollowingId(Long followerId, Long followingId);
+
+    boolean existsByFollowerIdAndFollowingId(Long followerId, Long followingId);
+
+    Page<Follow> findAllByFollowingId(Long followingId, Pageable pageable);
+
+    Page<Follow> findAllByFollowerId(Long followerId, Pageable pageable);
+
+    int countByFollowingId(Long followingId);
+
+    int countByFollowerId(Long followerId);
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/FollowRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/FollowRepository.java
@@ -1,0 +1,25 @@
+package com.prothsync.prothsync.repository.repository;
+
+import com.prothsync.prothsync.entity.user.Follow;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface FollowRepository {
+
+    Follow save(Follow follow);
+
+    Optional<Follow> findByFollowerIdAndFollowingId(Long followerId, Long followingId);
+
+    boolean existsByFollowerIdAndFollowingId(Long followerId, Long followingId);
+
+    Page<Follow> findAllByFollowingId(Long followingId, Pageable pageable);
+
+    Page<Follow> findAllByFollowerId(Long followerId, Pageable pageable);
+
+    void delete(Follow follow);
+
+    int countByFollowingId(Long followingId);
+
+    int countByFollowerId(Long followerId);
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/FollowService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/FollowService.java
@@ -1,0 +1,90 @@
+package com.prothsync.prothsync.service;
+
+import com.prothsync.prothsync.dto.FollowResponseDTO;
+import com.prothsync.prothsync.dto.FollowUserResponseDTO;
+import com.prothsync.prothsync.entity.user.Follow;
+import com.prothsync.prothsync.entity.user.User;
+import com.prothsync.prothsync.exception.BusinessException;
+import com.prothsync.prothsync.exception.UserErrorCode;
+import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.repository.repository.FollowRepository;
+import com.prothsync.prothsync.repository.repository.UserRepository;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FollowService {
+
+    private final FollowRepository followRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public FollowResponseDTO toggleFollow(Long followerId, Long followingId) {
+        User follower = findUserOrThrow(followerId);
+        User following = findUserOrThrow(followingId);
+
+        Optional<Follow> existingFollow = followRepository
+            .findByFollowerIdAndFollowingId(followerId, followingId);
+
+        if (existingFollow.isPresent()) {
+            followRepository.delete(existingFollow.get());
+            follower.decrementFollowingCount();
+            following.decrementFollowerCount();
+            userRepository.save(follower);
+            userRepository.save(following);
+            return FollowResponseDTO.of(followingId, false, following.getFollowerCount());
+        } else {
+            Follow follow = Follow.create(followerId, followingId);
+            followRepository.save(follow);
+            follower.incrementFollowingCount();
+            following.incrementFollowerCount();
+            userRepository.save(follower);
+            userRepository.save(following);
+            return FollowResponseDTO.of(followingId, true, following.getFollowerCount());
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isFollowing(Long followerId, Long followingId) {
+        return followRepository.existsByFollowerIdAndFollowingId(followerId, followingId);
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponse<FollowUserResponseDTO> getFollowers(Long userId, Pageable pageable) {
+        findUserOrThrow(userId);
+
+        Page<Follow> followPage = followRepository.findAllByFollowingId(userId, pageable);
+
+        List<FollowUserResponseDTO> followers = followPage.getContent().stream()
+            .map(follow -> findUserOrThrow(follow.getFollowerId()))
+            .map(FollowUserResponseDTO::from)
+            .toList();
+
+        return PageResponse.of(followers, followPage);
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponse<FollowUserResponseDTO> getFollowings(Long userId, Pageable pageable) {
+        findUserOrThrow(userId);
+
+        Page<Follow> followPage = followRepository.findAllByFollowerId(userId, pageable);
+
+        List<FollowUserResponseDTO> followings = followPage.getContent().stream()
+            .map(follow -> findUserOrThrow(follow.getFollowingId()))
+            .map(FollowUserResponseDTO::from)
+            .toList();
+
+        return PageResponse.of(followings, followPage);
+    }
+
+    private User findUserOrThrow(Long userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
# 변경사항

## 팔로우 기능 추가
- 사용자 간 팔로우/ 언팔로우 기능을 추가했습니다.

## Follow Entity
- followerId + followingId unidirectional ID 참조 방식
- uk_follows_follower_following 유니크 제약 조건
- 자기 자신 팔로우 방지 검증 로직 포함
- FollowErrorCode 신규 생성 (FOLLOWER_ID_NULL, FOLLOWING_ID_NULL, CANNOT_FOLLOW_SELF, FOLLOW_NOT_FOUND)

## User 
- User 엔티티에 followerCount, followingCount 필드 및 증감 메서드 추가

## SecurityConfig
- 팔로워/팔로잉 목록 공개 조회 permit all 추가
