### PR TITLE
feat: 간단하게 카카오 api 받는 정도 구현

### DIFF
--- a/prothsync/build.gradle
+++ b/prothsync/build.gradle
@@ -46,6 +46,8 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/prothsync/src/main/java/com/prothsync/prothsync/config/GeocodingConfig.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/config/GeocodingConfig.java
@@ -1,0 +1,27 @@
+package com.prothsync.prothsync.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class GeocodingConfig {
+
+    @Value("${kakao.rest-api-key}")
+    private String kakaoRestApiKey;
+
+    @Value("${kakao.geocoding.base-url}")
+    private String kakaoBaseUrl;
+
+    @Bean(name = "kakaoWebClient")
+    public WebClient kakaoWebClient() {
+        return WebClient.builder()
+            .baseUrl(kakaoBaseUrl)
+            .defaultHeader(HttpHeaders.AUTHORIZATION, "KakaoAK " + kakaoRestApiKey)
+            .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .build();
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/dto/SignupResponseDTO.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/dto/SignupResponseDTO.java
@@ -1,7 +1,6 @@
 package com.prothsync.prothsync.dto;
 
 import com.prothsync.prothsync.entity.user.User;
-import com.prothsync.prothsync.entity.user.UserRole;
 import com.prothsync.prothsync.entity.user.UserType;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -12,6 +11,8 @@ public record SignupResponseDTO(
     String nickName,
     LocalDate birthday,
     String address,
+    Double latitude,
+    Double longitude,
     String email,
     UserType userType,
     LocalDateTime createdAt
@@ -24,6 +25,8 @@ public record SignupResponseDTO(
             user.getNickName(),
             user.getBirthday(),
             user.getAddress(),
+            user.getLatitude(),
+            user.getLongitude(),
             user.getEmail(),
             user.getUserType(),
             user.getCreatedAt()

--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/user/User.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/user/User.java
@@ -45,6 +45,12 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private String address;
 
+    @Column
+    private Double latitude;
+
+    @Column
+    private Double longitude;
+
     @Column(nullable = false, unique = true)
     private String email;
 
@@ -176,6 +182,15 @@ public class User extends BaseEntity {
     public void updateEmail(String newEmail) {
         validateEmail(newEmail);
         this.email = newEmail;
+    }
+
+    public void updateCoordinates(Double latitude, Double longitude) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+
+    public boolean hasCoordinates() {
+        return this.latitude != null && this.longitude != null;
     }
 
     public void incrementFollowerCount() {

--- a/prothsync/src/main/java/com/prothsync/prothsync/exception/UserErrorCode.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/exception/UserErrorCode.java
@@ -24,6 +24,9 @@ public enum UserErrorCode implements ErrorCode {
     DUPLICATE_USERNAME(HttpStatus.CONFLICT, "이미 사용 중인 아이디입니다."),
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
+    GEOCODING_FAILED(HttpStatus.BAD_REQUEST, "주소를 좌표로 변환할 수 없습니다. 올바른 주소를 입력해주세요."),
+    USER_COORDINATES_NOT_SET(HttpStatus.BAD_REQUEST, "사용자의 위치 정보가 설정되지 않았습니다."),
+    INVALID_SEARCH_RADIUS(HttpStatus.BAD_REQUEST, "검색 반경이 유효하지 않습니다. (1~50km)"),
     ;
 
     private final HttpStatus status;

--- a/prothsync/src/main/resources/application.yaml
+++ b/prothsync/src/main/resources/application.yaml
@@ -27,3 +27,8 @@ jwt:
   secret: ${JWT_SECRET}
   access-token-expiration: ${JWT_ACCESS_EXPIRATION:1800000}
   refresh-token-expiration: ${JWT_REFRESH_EXPIRATION:604800000}
+
+kakao:
+  rest-api-key: ${KAKAO_REST_API_KEY}
+  geocoding:
+    base-url: https://dapis.kakao.com


### PR DESCRIPTION
# 변경사항
- 위도와 경도를 받아서 주변 사용자를 검색할 수 있게 했습니다. (의도: 근처 치과, 치기공소, 치기공실을 찾기 빠르게 하기 위해서)
- 카카오 api 키를  env에 작성 한 후 카카오 api키를 받을 수 있게 간단하게 설정했습니다.
- User entity에 위도 경도 추가 
