### PR TITLE
feat: 사용자 위치 기반 검색 기능 구현

### DIFF
--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/UserController.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/UserController.java
@@ -1,0 +1,56 @@
+package com.prothsync.prothsync.controller;
+
+import com.prothsync.prothsync.controller.docs.UserControllerDocs;
+import com.prothsync.prothsync.dto.NearbyUserResponseDTO;
+import com.prothsync.prothsync.entity.user.UserType;
+import com.prothsync.prothsync.security.CustomUserDetails;
+import com.prothsync.prothsync.service.UserService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+public class UserController implements UserControllerDocs {
+
+    private final UserService userService;
+
+    @GetMapping("/nearby")
+    public ResponseEntity<List<NearbyUserResponseDTO>> getNearbyUsers(
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        @RequestParam(required = false) Double radiusKm,
+        @RequestParam(required = false) Integer limit
+    ) {
+        List<NearbyUserResponseDTO> response = userService.findNearbyUsers(
+            userDetails.getUserId(), radiusKm, limit);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/nearby/{userType}")
+    public ResponseEntity<List<NearbyUserResponseDTO>> getNearbyUsersByType(
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        @PathVariable UserType userType,
+        @RequestParam(required = false) Double radiusKm,
+        @RequestParam(required = false) Integer limit
+    ) {
+        List<NearbyUserResponseDTO> response = userService.findNearbyUsersByType(
+            userDetails.getUserId(), userType, radiusKm, limit);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/me/geocode")
+    public ResponseEntity<Void> retryGeocoding(
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        userService.retryGeocoding(userDetails.getUserId());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/UserControllerDocs.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/UserControllerDocs.java
@@ -1,0 +1,78 @@
+package com.prothsync.prothsync.controller.docs;
+
+import com.prothsync.prothsync.dto.NearbyUserResponseDTO;
+import com.prothsync.prothsync.entity.user.UserType;
+import com.prothsync.prothsync.exception.ErrorResponse;
+import com.prothsync.prothsync.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "사용자", description = "사용자 정보 및 주변 검색 API")
+@SecurityRequirement(name = "bearerAuth")
+public interface UserControllerDocs {
+
+    @Operation(
+        summary = "주변 사업체 검색",
+        description = "현재 로그인한 사용자 위치 기준으로 반경 내 사업체(치과, 기공소)를 검색합니다."
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "검색 성공"),
+        @ApiResponse(
+            responseCode = "400",
+            description = "위치 정보 미설정 또는 잘못된 파라미터",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description = "인증 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<List<NearbyUserResponseDTO>> getNearbyUsers(
+        CustomUserDetails userDetails,
+        @Parameter(description = "검색 반경 (km, 기본값: 5, 최대: 50)") Double radiusKm,
+        @Parameter(description = "최대 결과 수 (기본값: 20)") Integer limit
+    );
+
+    @Operation(
+        summary = "유형별 주변 사업체 검색",
+        description = "현재 위치 기준으로 특정 유형의 주변 사업체를 검색합니다. 치과(DENTAL_CLINIC) 또는 기공소(DENTAL_LAB)만 검색 가능합니다."
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "검색 성공"),
+        @ApiResponse(
+            responseCode = "400",
+            description = "위치 정보 미설정, 잘못된 파라미터 또는 검색 불가능한 사용자 유형",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<List<NearbyUserResponseDTO>> getNearbyUsersByType(
+        CustomUserDetails userDetails,
+        @Parameter(description = "사업체 유형 (DENTAL_CLINIC: 치과, DENTAL_LAB: 기공소)")
+        UserType userType,
+        @Parameter(description = "검색 반경 (km)") Double radiusKm,
+        @Parameter(description = "최대 결과 수") Integer limit
+    );
+
+    @Operation(
+        summary = "위치 정보 재설정",
+        description = "현재 사용자의 주소로 좌표를 다시 계산합니다. 회원가입 시 지오코딩 실패한 경우 사용합니다."
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "좌표 재설정 성공"),
+        @ApiResponse(
+            responseCode = "400",
+            description = "좌표 변환 실패",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<Void> retryGeocoding(CustomUserDetails userDetails);
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/dto/NearbyUserResponseDTO.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/dto/NearbyUserResponseDTO.java
@@ -1,0 +1,43 @@
+package com.prothsync.prothsync.dto;
+
+import com.prothsync.prothsync.entity.user.User;
+import com.prothsync.prothsync.entity.user.UserType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "주변 사용자 응답 DTO")
+public record NearbyUserResponseDTO(
+
+    @Schema(description = "사용자 ID")
+    Long userId,
+
+    @Schema(description = "닉네임")
+    String nickName,
+
+    @Schema(description = "사용자 유형")
+    UserType userType,
+
+    @Schema(description = "주소")
+    String address,
+
+    @Schema(description = "위도")
+    Double latitude,
+
+    @Schema(description = "경도")
+    Double longitude,
+
+    @Schema(description = "거리 (km)")
+    double distanceKm
+) {
+
+    public static NearbyUserResponseDTO of(User user, double distanceKm) {
+        return new NearbyUserResponseDTO(
+            user.getUserId(),
+            user.getNickName(),
+            user.getUserType(),
+            user.getAddress(),
+            user.getLatitude(),
+            user.getLongitude(),
+            Math.round(distanceKm * 100.0) / 100.0
+        );
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/dto/SignupRequestDTO.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/dto/SignupRequestDTO.java
@@ -48,7 +48,8 @@ public record SignupRequestDTO(
     @Email(message = "유효한 이메일 형식이 아닙니다.")
     String email,
 
-    @Schema(description = "사용자 유형", example = "DENTIST")
+    @Schema(description = "사용자 유형 (DENTAL_CLINIC: 치과, DENTAL_LAB: 기공소, DENTAL_TECHNICIAN: 기공사, STUDENT: 학생)",
+        example = "DENTAL_CLINIC")
     @NotNull(message = "사용자 유형은 필수입니다.")
     UserType userType
 ) {

--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/user/UserType.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/user/UserType.java
@@ -1,14 +1,35 @@
 package com.prothsync.prothsync.entity.user;
 
+import java.util.Arrays;
+import java.util.List;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
 public enum UserType {
-    DENTIST("치과의사"),
-    DENTAL_LAB_OWNER("기공소장"),
+    DENTAL_CLINIC("치과"),
+    DENTAL_LAB("기공소"),
     DENTAL_TECHNICIAN("기공사"),
     STUDENT("학생");
+
     private final String description;
+
+    /**
+     * 위치 기반 검색 대상인지 여부
+     * 사업체(치과, 기공소)만 검색 가능
+     */
+    public boolean isSearchableByLocation() {
+        return this == DENTAL_CLINIC || this == DENTAL_LAB;
+    }
+
+    /**
+     * 위치 검색 가능한 UserType 목록 반환
+     */
+    public static List<String> getSearchableTypeNames() {
+        return Arrays.stream(values())
+            .filter(UserType::isSearchableByLocation)
+            .map(Enum::name)
+            .toList();
+    }
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/exception/UserErrorCode.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/exception/UserErrorCode.java
@@ -27,6 +27,7 @@ public enum UserErrorCode implements ErrorCode {
     GEOCODING_FAILED(HttpStatus.BAD_REQUEST, "주소를 좌표로 변환할 수 없습니다. 올바른 주소를 입력해주세요."),
     USER_COORDINATES_NOT_SET(HttpStatus.BAD_REQUEST, "사용자의 위치 정보가 설정되지 않았습니다."),
     INVALID_SEARCH_RADIUS(HttpStatus.BAD_REQUEST, "검색 반경이 유효하지 않습니다. (1~50km)"),
+    UNSEARCHABLE_USER_TYPE(HttpStatus.BAD_REQUEST, "해당 사용자 유형은 위치 검색 대상이 아닙니다. (치과, 기공소만 검색 가능)"),
     ;
 
     private final HttpStatus status;

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/UserRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/UserRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.prothsync.prothsync.repository.impl;
 import com.prothsync.prothsync.entity.user.User;
 import com.prothsync.prothsync.repository.jpa.UserJpaRepository;
 import com.prothsync.prothsync.repository.repository.UserRepository;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -20,7 +21,7 @@ public class UserRepositoryImpl implements UserRepository {
 
     @Override
     public boolean existsByUserName(String userName) {
-         return userJpaRepository.existsByUserName(userName);
+        return userJpaRepository.existsByUserName(userName);
     }
 
     @Override
@@ -41,5 +42,19 @@ public class UserRepositoryImpl implements UserRepository {
     @Override
     public Optional<User> findByUserName(String userName) {
         return userJpaRepository.findByUserName(userName);
+    }
+
+    @Override
+    public List<User> findNearbyUsers(double lat, double lng, double radiusKm,
+        Long excludeUserId, List<String> searchableTypes, int limit) {
+        return userJpaRepository.findNearbyUsers(lat, lng, radiusKm, excludeUserId,
+            searchableTypes, limit);
+    }
+
+    @Override
+    public List<User> findNearbyUsersByType(double lat, double lng, double radiusKm,
+        Long excludeUserId, String userType, int limit) {
+        return userJpaRepository.findNearbyUsersByType(lat, lng, radiusKm, excludeUserId,
+            userType, limit);
     }
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/UserJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/UserJpaRepository.java
@@ -1,8 +1,11 @@
 package com.prothsync.prothsync.repository.jpa;
 
 import com.prothsync.prothsync.entity.user.User;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserJpaRepository extends JpaRepository<User, Long> {
 
@@ -14,5 +17,81 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByUserName(String userName);
 
+    /**
+     * Haversine 공식을 이용한 주변 사용자 검색
+     * 사업체(치과, 기공소)만 검색되도록 userType IN 조건 포함
+     */
+    @Query(value = """
+        SELECT u.* FROM users u
+        WHERE u.latitude IS NOT NULL
+          AND u.longitude IS NOT NULL
+          AND u.user_id != :excludeUserId
+          AND u.user_type IN (:searchableTypes)
+          AND (
+            6371 * acos(
+              LEAST(1.0, GREATEST(-1.0,
+                cos(radians(:lat)) * cos(radians(u.latitude))
+                * cos(radians(u.longitude) - radians(:lng))
+                + sin(radians(:lat)) * sin(radians(u.latitude))
+              ))
+            )
+          ) < :radiusKm
+        ORDER BY (
+            6371 * acos(
+              LEAST(1.0, GREATEST(-1.0,
+                cos(radians(:lat)) * cos(radians(u.latitude))
+                * cos(radians(u.longitude) - radians(:lng))
+                + sin(radians(:lat)) * sin(radians(u.latitude))
+              ))
+            )
+          ) ASC
+        LIMIT :limit
+        """, nativeQuery = true)
+    List<User> findNearbyUsers(
+        @Param("lat") double lat,
+        @Param("lng") double lng,
+        @Param("radiusKm") double radiusKm,
+        @Param("excludeUserId") Long excludeUserId,
+        @Param("searchableTypes") List<String> searchableTypes,
+        @Param("limit") int limit
+    );
 
+    /**
+     * 특정 사용자 유형으로 필터링한 주변 검색
+     * (치과 또는 기공소 중 하나만 선택해서 검색)
+     */
+    @Query(value = """
+        SELECT u.* FROM users u
+        WHERE u.latitude IS NOT NULL
+          AND u.longitude IS NOT NULL
+          AND u.user_id != :excludeUserId
+          AND u.user_type = :userType
+          AND (
+            6371 * acos(
+              LEAST(1.0, GREATEST(-1.0,
+                cos(radians(:lat)) * cos(radians(u.latitude))
+                * cos(radians(u.longitude) - radians(:lng))
+                + sin(radians(:lat)) * sin(radians(u.latitude))
+              ))
+            )
+          ) < :radiusKm
+        ORDER BY (
+            6371 * acos(
+              LEAST(1.0, GREATEST(-1.0,
+                cos(radians(:lat)) * cos(radians(u.latitude))
+                * cos(radians(u.longitude) - radians(:lng))
+                + sin(radians(:lat)) * sin(radians(u.latitude))
+              ))
+            )
+          ) ASC
+        LIMIT :limit
+        """, nativeQuery = true)
+    List<User> findNearbyUsersByType(
+        @Param("lat") double lat,
+        @Param("lng") double lng,
+        @Param("radiusKm") double radiusKm,
+        @Param("excludeUserId") Long excludeUserId,
+        @Param("userType") String userType,
+        @Param("limit") int limit
+    );
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/UserRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.prothsync.prothsync.repository.repository;
 
 import com.prothsync.prothsync.entity.user.User;
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository {
@@ -11,4 +12,9 @@ public interface UserRepository {
     boolean existsByEmail(String email);
     Optional<User> findById(Long userId);
     Optional<User> findByUserName(String userName);
+
+    List<User> findNearbyUsers(double lat, double lng, double radiusKm,
+        Long excludeUserId, List<String> searchableTypes, int limit);
+    List<User> findNearbyUsersByType(double lat, double lng, double radiusKm,
+        Long excludeUserId, String userType, int limit);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/AuthService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/AuthService.java
@@ -12,12 +12,15 @@ import com.prothsync.prothsync.exception.UserErrorCode;
 import com.prothsync.prothsync.repository.repository.RefreshTokenRepository;
 import com.prothsync.prothsync.repository.repository.UserRepository;
 import com.prothsync.prothsync.security.JwtTokenProvider;
+import com.prothsync.prothsync.service.GeocodingService.GeocodingResult;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthService {
@@ -27,6 +30,7 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
     private final TokenBlacklistService tokenBlacklistService;
+    private final GeocodingService geocodingService;
 
     @Transactional
     public User signup(SignupRequestDTO signupRequest) {
@@ -45,6 +49,7 @@ public class AuthService {
             signupRequest.email(),
             signupRequest.userType()
         );
+        geocodeAndSetCoordinates(user, signupRequest.address());
 
         return userRepository.save(user);
     }
@@ -110,6 +115,18 @@ public class AuthService {
         if (accessToken != null && jwtTokenProvider.validateToken(accessToken)) {
             Duration remainingTime = jwtTokenProvider.getRemainingTime(accessToken);
             tokenBlacklistService.addToBlackList(accessToken, remainingTime);
+        }
+    }
+
+    private void geocodeAndSetCoordinates(User user, String address) {
+        GeocodingResult result = geocodingService.geocode(address);
+
+        if (result.success()) {
+            user.updateCoordinates(result.latitude(), result.longitude());
+            log.info("회원가입 지오코딩 성공 - 주소: {}, 위도: {}, 경도: {}",
+                address, result.latitude(), result.longitude());
+        } else {
+            log.warn("회원가입 지오코딩 실패 - 주소: {}. 좌표 없이 저장합니다.", address);
         }
     }
 

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/GeocodingService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/GeocodingService.java
@@ -1,0 +1,22 @@
+package com.prothsync.prothsync.service;
+
+public interface GeocodingService {
+
+    GeocodingResult geocode(String address);
+
+
+    record GeocodingResult(
+        Double latitude,
+        Double longitude,
+        boolean success
+    ){
+        public static GeocodingResult success(Double latitude, Double longitude){
+            return new GeocodingResult(latitude, longitude, true);
+        }
+
+        public static GeocodingResult fail(){
+            return new GeocodingResult(null,null,false);
+        }
+    }
+
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/KakaoGeocodingService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/KakaoGeocodingService.java
@@ -1,0 +1,70 @@
+package com.prothsync.prothsync.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+@Slf4j
+@Service
+public class KakaoGeocodingService implements GeocodingService {
+
+    private final WebClient kakaoWebClient;
+
+    public KakaoGeocodingService(@Qualifier("kakaoWebClient") WebClient kakaoWebClient) {
+        this.kakaoWebClient = kakaoWebClient;
+    }
+
+    @Override
+    public GeocodingResult geocode(String address) {
+        if (address == null || address.isBlank()) {
+            log.warn("지오코딩 요청 주소가 비어있습니다.");
+            return GeocodingResult.fail();
+        }
+
+        try {
+            JsonNode response = kakaoWebClient.get()
+                .uri(uriBuilder -> uriBuilder
+                    .path("/v2/local/search/address.json")
+                    .queryParam("query", address)
+                    .queryParam("analyze_type", "similar")
+                    .build())
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .block();
+
+            return parseResponse(response, address);
+
+        } catch (WebClientResponseException e) {
+            log.error("Kakao Geocoding API 호출 실패 - 상태코드: {}, 주소: {}",
+                e.getStatusCode(), address);
+            return GeocodingResult.fail();
+        } catch (Exception e) {
+            log.error("Kakao Geocoding API 호출 중 예외 발생 - 주소: {}", address, e);
+            return GeocodingResult.fail();
+        }
+    }
+
+    private GeocodingResult parseResponse(JsonNode response, String address) {
+        if (response == null) {
+            log.warn("Kakao Geocoding API 응답이 null입니다. 주소: {}", address);
+            return GeocodingResult.fail();
+        }
+
+        JsonNode documents = response.get("documents");
+        if (documents == null || documents.isEmpty()) {
+            log.warn("Kakao Geocoding API 검색 결과가 없습니다. 주소: {}", address);
+            return GeocodingResult.fail();
+        }
+
+        JsonNode firstResult = documents.get(0);
+        // Kakao API에서 x = 경도(longitude), y = 위도(latitude)
+        Double longitude = firstResult.get("x").asDouble();
+        Double latitude = firstResult.get("y").asDouble();
+
+        log.debug("지오코딩 성공 - 주소: {}, 위도: {}, 경도: {}", address, latitude, longitude);
+        return GeocodingResult.success(latitude, longitude);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/UserService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/UserService.java
@@ -1,0 +1,181 @@
+package com.prothsync.prothsync.service;
+
+import com.prothsync.prothsync.dto.NearbyUserResponseDTO;
+import com.prothsync.prothsync.entity.user.User;
+import com.prothsync.prothsync.entity.user.UserType;
+import com.prothsync.prothsync.exception.BusinessException;
+import com.prothsync.prothsync.exception.UserErrorCode;
+import com.prothsync.prothsync.repository.repository.UserRepository;
+import com.prothsync.prothsync.service.GeocodingService.GeocodingResult;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private static final double DEFAULT_RADIUS_KM = 5.0;
+    private static final double MAX_RADIUS_KM = 50.0;
+    private static final double MIN_RADIUS_KM = 1.0;
+    private static final int DEFAULT_LIMIT = 20;
+
+    private final UserRepository userRepository;
+    private final GeocodingService geocodingService;
+
+    /**
+     * 현재 사용자 기준 주변 사업체(치과, 기공소) 검색
+     */
+    @Transactional(readOnly = true)
+    public List<NearbyUserResponseDTO> findNearbyUsers(
+        Long currentUserId, Double radiusKm, Integer limit) {
+
+        User currentUser = findUserOrThrow(currentUserId);
+        validateUserHasCoordinates(currentUser);
+
+        double radius = resolveRadius(radiusKm);
+        int resultLimit = resolveLimit(limit);
+
+        List<String> searchableTypes = UserType.getSearchableTypeNames();
+
+        List<User> nearbyUsers = userRepository.findNearbyUsers(
+            currentUser.getLatitude(),
+            currentUser.getLongitude(),
+            radius,
+            currentUserId,
+            searchableTypes,
+            resultLimit
+        );
+
+        return nearbyUsers.stream()
+            .map(user -> NearbyUserResponseDTO.of(user,
+                calculateDistance(currentUser, user)))
+            .toList();
+    }
+
+    /**
+     * 현재 사용자 기준 특정 유형의 주변 사업체 검색
+     * (치과 또는 기공소만 검색 가능)
+     */
+    @Transactional(readOnly = true)
+    public List<NearbyUserResponseDTO> findNearbyUsersByType(
+        Long currentUserId, UserType userType, Double radiusKm, Integer limit) {
+
+        User currentUser = findUserOrThrow(currentUserId);
+        validateUserHasCoordinates(currentUser);
+        validateSearchableType(userType);
+
+        double radius = resolveRadius(radiusKm);
+        int resultLimit = resolveLimit(limit);
+
+        List<User> nearbyUsers = userRepository.findNearbyUsersByType(
+            currentUser.getLatitude(),
+            currentUser.getLongitude(),
+            radius,
+            currentUserId,
+            userType.name(),
+            resultLimit
+        );
+
+        return nearbyUsers.stream()
+            .map(user -> NearbyUserResponseDTO.of(user,
+                calculateDistance(currentUser, user)))
+            .toList();
+    }
+
+    /**
+     * 사용자 주소 변경 시 좌표 재계산
+     */
+    @Transactional
+    public void updateUserAddress(Long userId, String newAddress) {
+        User user = findUserOrThrow(userId);
+        user.updateAddress(newAddress);
+
+        GeocodingResult result = geocodingService.geocode(newAddress);
+        if (result.success()) {
+            user.updateCoordinates(result.latitude(), result.longitude());
+            log.info("주소 변경 지오코딩 성공 - userId: {}, 주소: {}", userId, newAddress);
+        } else {
+            user.updateCoordinates(null, null);
+            log.warn("주소 변경 지오코딩 실패 - userId: {}, 주소: {}", userId, newAddress);
+        }
+
+        userRepository.save(user);
+    }
+
+    /**
+     * 좌표가 없는 사용자의 좌표를 수동으로 재시도
+     */
+    @Transactional
+    public void retryGeocoding(Long userId) {
+        User user = findUserOrThrow(userId);
+
+        GeocodingResult result = geocodingService.geocode(user.getAddress());
+        if (result.success()) {
+            user.updateCoordinates(result.latitude(), result.longitude());
+            userRepository.save(user);
+            log.info("지오코딩 재시도 성공 - userId: {}", userId);
+        } else {
+            throw new BusinessException(UserErrorCode.GEOCODING_FAILED);
+        }
+    }
+
+    private User findUserOrThrow(Long userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    private void validateUserHasCoordinates(User user) {
+        if (!user.hasCoordinates()) {
+            throw new BusinessException(UserErrorCode.USER_COORDINATES_NOT_SET);
+        }
+    }
+
+    /**
+     * 위치 검색 가능한 사용자 유형인지 검증
+     */
+    private void validateSearchableType(UserType userType) {
+        if (!userType.isSearchableByLocation()) {
+            throw new BusinessException(UserErrorCode.UNSEARCHABLE_USER_TYPE);
+        }
+    }
+
+    private double resolveRadius(Double radiusKm) {
+        if (radiusKm == null) {
+            return DEFAULT_RADIUS_KM;
+        }
+        if (radiusKm < MIN_RADIUS_KM || radiusKm > MAX_RADIUS_KM) {
+            throw new BusinessException(UserErrorCode.INVALID_SEARCH_RADIUS);
+        }
+        return radiusKm;
+    }
+
+    private int resolveLimit(Integer limit) {
+        if (limit == null || limit <= 0) {
+            return DEFAULT_LIMIT;
+        }
+        return Math.min(limit, 50);
+    }
+
+    /**
+     * Haversine 공식으로 두 사용자 간 거리(km) 계산
+     */
+    private double calculateDistance(User from, User to) {
+        double earthRadiusKm = 6371.0;
+
+        double latDistance = Math.toRadians(to.getLatitude() - from.getLatitude());
+        double lngDistance = Math.toRadians(to.getLongitude() - from.getLongitude());
+
+        double a = Math.sin(latDistance / 2) * Math.sin(latDistance / 2)
+            + Math.cos(Math.toRadians(from.getLatitude()))
+            * Math.cos(Math.toRadians(to.getLatitude()))
+            * Math.sin(lngDistance / 2) * Math.sin(lngDistance / 2);
+
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+        return earthRadiusKm * c;
+    }
+}


### PR DESCRIPTION
# 변경사항
-  사용자 주소를 기반으로 좌표(위도/경도)를 자동 변환하고, 주변 사업체 (치과, 기공소)를 검색할 수 있는 위치 기반 서비스를 구현합니다

- Kakao Geocoding API를 활용하여 회원가입 시 주소 -> 좌표변환을 수행하고, 하버사인 공식을 이용한 거리 계산으로 PostGIS 없이 반경 기반 검색을 지원합니다.

## 주요 기능
### 1. 회원가입 시 자동 지오코딩
- 사용자가 입력한 주소를 kakao API로 위도/경도 좌표로 자동 변환
- 지오코딩 실패 시에도 회원가입은 정상 진행 (좌표 자리에 null로)
- 이후 별도의 API로 수동 재시도 가능

### 2. 주변 사업체 검색
- 현재 사용자 좌표 기준 반경 내 사업체를 거리순으로 조회
- 전체 사업체 검색 및 유형별 검색
- 검색 반경, 결과 수 제한 파라미터 지원

### 사업체 전용 위치 검색
- 기공사 및 학생은 개인 사용자이므로 위치 검색 대상에서 제외
- 치과, 기공소만 검색 가능하도록 비즈니스 규칙 적용

## 아키텍처 및 설계 결정
### kakao API
- GeocodingService 인터페이스 -> kakaoGeocodingService 구현체 구조로 향후 다른 지오코딩 서비스로 교체 가능
-GeocodingConfig에서 WebClient Bean을 생성하여  API키와 BaseURL을 중앙 관리
GeocodingResult record를 통해 성공/실패를 명시적으로 구분

### 하버사인 공식 기반 거리 계산
- PostgreSQL Native Query에서 하버사인 공식으로 거리 계산 및 필터링
- PostGIS 확장 없이 순수 SQL로 구현하여 인프라 의존성 최소화


## 변경
User_type에서
 치과의사 -> 치과
기공소장 -> 기공소
로 변경
