### PR TITLE
feat: 사용자 프로필 조회/수정 기능 구현

### DIFF
--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/UserController.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/UserController.java
@@ -1,17 +1,23 @@
 package com.prothsync.prothsync.controller;
 
 import com.prothsync.prothsync.controller.docs.UserControllerDocs;
+import com.prothsync.prothsync.dto.MyProfileResponseDTO;
 import com.prothsync.prothsync.dto.NearbyUserResponseDTO;
+import com.prothsync.prothsync.dto.ProfileUpdateRequestDTO;
+import com.prothsync.prothsync.dto.UserProfileResponseDTO;
 import com.prothsync.prothsync.entity.user.UserType;
 import com.prothsync.prothsync.security.CustomUserDetails;
 import com.prothsync.prothsync.service.UserService;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,6 +28,34 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController implements UserControllerDocs {
 
     private final UserService userService;
+
+    @GetMapping("/me")
+    public ResponseEntity<MyProfileResponseDTO> getMyProfile(
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        MyProfileResponseDTO response = userService.getMyProfile(userDetails.getUserId());
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<UserProfileResponseDTO> getUserProfile(
+        @PathVariable Long userId,
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        UserProfileResponseDTO response = userService.getUserProfile(
+            userId, userDetails.getUserId());
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/me")
+    public ResponseEntity<MyProfileResponseDTO> updateProfile(
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        @Valid @RequestBody ProfileUpdateRequestDTO request
+    ) {
+        MyProfileResponseDTO response = userService.updateProfile(
+            userDetails.getUserId(), request);
+        return ResponseEntity.ok(response);
+    }
 
     @GetMapping("/nearby")
     public ResponseEntity<List<NearbyUserResponseDTO>> getNearbyUsers(

--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/UserControllerDocs.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/UserControllerDocs.java
@@ -1,6 +1,9 @@
 package com.prothsync.prothsync.controller.docs;
 
+import com.prothsync.prothsync.dto.MyProfileResponseDTO;
 import com.prothsync.prothsync.dto.NearbyUserResponseDTO;
+import com.prothsync.prothsync.dto.ProfileUpdateRequestDTO;
+import com.prothsync.prothsync.dto.UserProfileResponseDTO;
 import com.prothsync.prothsync.entity.user.UserType;
 import com.prothsync.prothsync.exception.ErrorResponse;
 import com.prothsync.prothsync.security.CustomUserDetails;
@@ -15,9 +18,64 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 
-@Tag(name = "사용자", description = "사용자 정보 및 주변 검색 API")
+@Tag(name = "사용자", description = "사용자 프로필 및 주변 검색 API")
 @SecurityRequirement(name = "bearerAuth")
 public interface UserControllerDocs {
+
+    @Operation(
+        summary = "내 프로필 조회",
+        description = "현재 로그인한 사용자의 전체 프로필 정보를 조회합니다. (이메일, 생년월일, 좌표 등 민감 정보 포함)"
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공"),
+        @ApiResponse(
+            responseCode = "401",
+            description = "인증 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<MyProfileResponseDTO> getMyProfile(CustomUserDetails userDetails);
+
+    @Operation(
+        summary = "사용자 프로필 조회",
+        description = "특정 사용자의 공개 프로필 정보를 조회합니다. 로그인 사용자 기준 팔로우 여부를 포함합니다."
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공"),
+        @ApiResponse(
+            responseCode = "404",
+            description = "사용자를 찾을 수 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<UserProfileResponseDTO> getUserProfile(
+        @Parameter(description = "조회할 사용자 ID") Long userId,
+        CustomUserDetails userDetails
+    );
+
+    @Operation(
+        summary = "프로필 수정",
+        description = "현재 로그인한 사용자의 프로필을 수정합니다. 변경할 필드만 전달하면 됩니다 (부분 수정 지원). "
+            + "주소 변경 시 좌표가 자동으로 재계산됩니다."
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "수정 성공"),
+        @ApiResponse(
+            responseCode = "400",
+            description = "유효하지 않은 입력값",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description = "닉네임 또는 이메일 중복",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<MyProfileResponseDTO> updateProfile(
+        CustomUserDetails userDetails,
+        ProfileUpdateRequestDTO request
+    );
+
 
     @Operation(
         summary = "주변 사업체 검색",

--- a/prothsync/src/main/java/com/prothsync/prothsync/dto/MyProfileResponseDTO.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/dto/MyProfileResponseDTO.java
@@ -1,0 +1,73 @@
+package com.prothsync.prothsync.dto;
+
+import com.prothsync.prothsync.entity.user.User;
+import com.prothsync.prothsync.entity.user.UserType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Schema(description = "내 프로필 응답 DTO")
+public record MyProfileResponseDTO(
+
+    @Schema(description = "사용자 ID")
+    Long userId,
+
+    @Schema(description = "사용자 아이디")
+    String userName,
+
+    @Schema(description = "닉네임")
+    String nickName,
+
+    @Schema(description = "자기소개")
+    String bio,
+
+    @Schema(description = "프로필 이미지 URL")
+    String profileImageUrl,
+
+    @Schema(description = "생년월일")
+    LocalDate birthday,
+
+    @Schema(description = "주소")
+    String address,
+
+    @Schema(description = "이메일")
+    String email,
+
+    @Schema(description = "사용자 유형")
+    UserType userType,
+
+    @Schema(description = "팔로워 수")
+    int followerCount,
+
+    @Schema(description = "팔로잉 수")
+    int followingCount,
+
+    @Schema(description = "위도")
+    Double latitude,
+
+    @Schema(description = "경도")
+    Double longitude,
+
+    @Schema(description = "가입일")
+    LocalDateTime createdAt
+) {
+
+    public static MyProfileResponseDTO from(User user) {
+        return new MyProfileResponseDTO(
+            user.getUserId(),
+            user.getUserName(),
+            user.getNickName(),
+            user.getBio(),
+            user.getProfileImageUrl(),
+            user.getBirthday(),
+            user.getAddress(),
+            user.getEmail(),
+            user.getUserType(),
+            user.getFollowerCount(),
+            user.getFollowingCount(),
+            user.getLatitude(),
+            user.getLongitude(),
+            user.getCreatedAt()
+        );
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/dto/ProfileUpdateRequestDTO.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/dto/ProfileUpdateRequestDTO.java
@@ -1,0 +1,28 @@
+package com.prothsync.prothsync.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "프로필 수정 요청 DTO")
+public record ProfileUpdateRequestDTO(
+
+    @Schema(description = "닉네임", example = "새닉네임")
+    @Size(max = 10, message = "닉네임은 10자를 초과할 수 없습니다.")
+    String nickName,
+
+    @Schema(description = "자기소개", example = "안녕하세요, 보철 전문 치과의사입니다.")
+    @Size(max = 200, message = "자기소개는 200자를 초과할 수 없습니다.")
+    String bio,
+
+    @Schema(description = "프로필 이미지 URL", example = "https://s3.amazonaws.com/prothsync/profiles/1.jpg")
+    String profileImageUrl,
+
+    @Schema(description = "주소", example = "서울시 강남구 테헤란로 456")
+    String address,
+
+    @Schema(description = "이메일", example = "new@example.com")
+    @Email(message = "유효한 이메일 형식이 아닙니다.")
+    String email
+) {
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/dto/UserProfileResponseDTO.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/dto/UserProfileResponseDTO.java
@@ -1,0 +1,56 @@
+package com.prothsync.prothsync.dto;
+
+import com.prothsync.prothsync.entity.user.User;
+import com.prothsync.prothsync.entity.user.UserType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "사용자 프로필 응답 DTO")
+public record UserProfileResponseDTO(
+
+    @Schema(description = "사용자 ID")
+    Long userId,
+
+    @Schema(description = "닉네임")
+    String nickName,
+
+    @Schema(description = "자기소개")
+    String bio,
+
+    @Schema(description = "프로필 이미지 URL")
+    String profileImageUrl,
+
+    @Schema(description = "사용자 유형")
+    UserType userType,
+
+    @Schema(description = "주소")
+    String address,
+
+    @Schema(description = "팔로워 수")
+    int followerCount,
+
+    @Schema(description = "팔로잉 수")
+    int followingCount,
+
+    @Schema(description = "팔로우 여부 (로그인 사용자 기준)")
+    boolean isFollowing,
+
+    @Schema(description = "가입일")
+    LocalDateTime createdAt
+) {
+
+    public static UserProfileResponseDTO of(User user, boolean isFollowing) {
+        return new UserProfileResponseDTO(
+            user.getUserId(),
+            user.getNickName(),
+            user.getBio(),
+            user.getProfileImageUrl(),
+            user.getUserType(),
+            user.getAddress(),
+            user.getFollowerCount(),
+            user.getFollowingCount(),
+            isFollowing,
+            user.getCreatedAt()
+        );
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/user/User.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/user/User.java
@@ -26,6 +26,8 @@ public class User extends BaseEntity {
     private static final Pattern EMAIL_PATTERN =
         Pattern.compile("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$");
 
+    private static final int BIO_MAX_LENGTH = 200;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long userId;
@@ -67,6 +69,12 @@ public class User extends BaseEntity {
 
     @Column(nullable = false)
     private int followingCount = 0;
+
+    @Column(length = 200)
+    private String bio;
+
+    @Column(length = 500)
+    private String profileImageUrl;
 
     private User(String userName,
         String password,
@@ -164,6 +172,12 @@ public class User extends BaseEntity {
         }
     }
 
+    private static void validateBio(String bio) {
+        if (bio != null && bio.length() > BIO_MAX_LENGTH) {
+            throw new BusinessException(UserErrorCode.BIO_TOO_LONG);
+        }
+    }
+
     public void updatePassword(String newPassword) {
         validatePassword(newPassword);
         this.password = newPassword;
@@ -182,6 +196,15 @@ public class User extends BaseEntity {
     public void updateEmail(String newEmail) {
         validateEmail(newEmail);
         this.email = newEmail;
+    }
+
+    public void updateBio(String newBio) {
+        validateBio(newBio);
+        this.bio = newBio;
+    }
+
+    public void updateProfileImageUrl(String newProfileImageUrl) {
+        this.profileImageUrl = newProfileImageUrl;
     }
 
     public void updateCoordinates(Double latitude, Double longitude) {

--- a/prothsync/src/main/java/com/prothsync/prothsync/exception/UserErrorCode.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/exception/UserErrorCode.java
@@ -21,6 +21,7 @@ public enum UserErrorCode implements ErrorCode {
     USER_TYPE_IS_NULL(HttpStatus.BAD_REQUEST, "사용자 유형이 비어 있습니다."),
     USERNAME_TOO_LONG(HttpStatus.BAD_REQUEST, "아이디는 20자를 초과할 수 없습니다."),
     NICKNAME_TOO_LONG(HttpStatus.BAD_REQUEST, "닉네임은 10자를 초과할 수 없습니다."),
+    BIO_TOO_LONG(HttpStatus.BAD_REQUEST, "자기소개는 200자를 초과할 수 없습니다."),
     DUPLICATE_USERNAME(HttpStatus.CONFLICT, "이미 사용 중인 아이디입니다."),
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/UserRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/UserRepositoryImpl.java
@@ -45,6 +45,16 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
+    public Optional<User> findByNickName(String nickName) {
+        return userJpaRepository.findByNickName(nickName);
+    }
+
+    @Override
+    public Optional<User> findByEmail(String email) {
+        return userJpaRepository.findByEmail(email);
+    }
+
+    @Override
     public List<User> findNearbyUsers(double lat, double lng, double radiusKm,
         Long excludeUserId, List<String> searchableTypes, int limit) {
         return userJpaRepository.findNearbyUsers(lat, lng, radiusKm, excludeUserId,

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/UserJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/UserJpaRepository.java
@@ -17,6 +17,10 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByUserName(String userName);
 
+    Optional<User> findByNickName(String nickName);
+
+    Optional<User> findByEmail(String email);
+
     /**
      * Haversine 공식을 이용한 주변 사용자 검색
      * 사업체(치과, 기공소)만 검색되도록 userType IN 조건 포함

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/UserRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/UserRepository.java
@@ -12,6 +12,8 @@ public interface UserRepository {
     boolean existsByEmail(String email);
     Optional<User> findById(Long userId);
     Optional<User> findByUserName(String userName);
+    Optional<User> findByNickName(String nickName);
+    Optional<User> findByEmail(String email);
 
     List<User> findNearbyUsers(double lat, double lng, double radiusKm,
         Long excludeUserId, List<String> searchableTypes, int limit);

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/UserService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/UserService.java
@@ -1,10 +1,14 @@
 package com.prothsync.prothsync.service;
 
+import com.prothsync.prothsync.dto.MyProfileResponseDTO;
 import com.prothsync.prothsync.dto.NearbyUserResponseDTO;
+import com.prothsync.prothsync.dto.ProfileUpdateRequestDTO;
+import com.prothsync.prothsync.dto.UserProfileResponseDTO;
 import com.prothsync.prothsync.entity.user.User;
 import com.prothsync.prothsync.entity.user.UserType;
 import com.prothsync.prothsync.exception.BusinessException;
 import com.prothsync.prothsync.exception.UserErrorCode;
+import com.prothsync.prothsync.repository.repository.FollowRepository;
 import com.prothsync.prothsync.repository.repository.UserRepository;
 import com.prothsync.prothsync.service.GeocodingService.GeocodingResult;
 import java.util.List;
@@ -24,7 +28,71 @@ public class UserService {
     private static final int DEFAULT_LIMIT = 20;
 
     private final UserRepository userRepository;
+    private final FollowRepository followRepository;
     private final GeocodingService geocodingService;
+
+    // ============================================================
+    // 프로필 조회/수정
+    // ============================================================
+
+    /**
+     * 내 프로필 조회 (전체 정보 포함)
+     */
+    @Transactional(readOnly = true)
+    public MyProfileResponseDTO getMyProfile(Long userId) {
+        User user = findUserOrThrow(userId);
+        return MyProfileResponseDTO.from(user);
+    }
+
+    /**
+     * 다른 사용자 프로필 조회 (공개 정보 + 팔로우 여부)
+     */
+    @Transactional(readOnly = true)
+    public UserProfileResponseDTO getUserProfile(Long targetUserId, Long currentUserId) {
+        User targetUser = findUserOrThrow(targetUserId);
+
+        boolean isFollowing = false;
+        if (currentUserId != null && !currentUserId.equals(targetUserId)) {
+            isFollowing = followRepository.existsByFollowerIdAndFollowingId(
+                currentUserId, targetUserId);
+        }
+
+        return UserProfileResponseDTO.of(targetUser, isFollowing);
+    }
+
+    /**
+     * 프로필 수정 (부분 수정 지원)
+     */
+    @Transactional
+    public MyProfileResponseDTO updateProfile(Long userId, ProfileUpdateRequestDTO request) {
+        User user = findUserOrThrow(userId);
+
+        if (request.nickName() != null) {
+            validateNickNameNotDuplicate(userId, request.nickName());
+            user.updateNickName(request.nickName());
+        }
+        if (request.bio() != null) {
+            user.updateBio(request.bio());
+        }
+        if (request.profileImageUrl() != null) {
+            user.updateProfileImageUrl(request.profileImageUrl());
+        }
+        if (request.email() != null) {
+            validateEmailNotDuplicate(userId, request.email());
+            user.updateEmail(request.email());
+        }
+        if (request.address() != null) {
+            user.updateAddress(request.address());
+            geocodeAndUpdateCoordinates(user, request.address());
+        }
+
+        userRepository.save(user);
+        return MyProfileResponseDTO.from(user);
+    }
+
+    // ============================================================
+    // 주변 사용자 검색
+    // ============================================================
 
     /**
      * 현재 사용자 기준 주변 사업체(치과, 기공소) 검색
@@ -93,16 +161,7 @@ public class UserService {
     public void updateUserAddress(Long userId, String newAddress) {
         User user = findUserOrThrow(userId);
         user.updateAddress(newAddress);
-
-        GeocodingResult result = geocodingService.geocode(newAddress);
-        if (result.success()) {
-            user.updateCoordinates(result.latitude(), result.longitude());
-            log.info("주소 변경 지오코딩 성공 - userId: {}, 주소: {}", userId, newAddress);
-        } else {
-            user.updateCoordinates(null, null);
-            log.warn("주소 변경 지오코딩 실패 - userId: {}, 주소: {}", userId, newAddress);
-        }
-
+        geocodeAndUpdateCoordinates(user, newAddress);
         userRepository.save(user);
     }
 
@@ -123,6 +182,10 @@ public class UserService {
         }
     }
 
+    // ============================================================
+    // Private helpers
+    // ============================================================
+
     private User findUserOrThrow(Long userId) {
         return userRepository.findById(userId)
             .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
@@ -140,6 +203,42 @@ public class UserService {
     private void validateSearchableType(UserType userType) {
         if (!userType.isSearchableByLocation()) {
             throw new BusinessException(UserErrorCode.UNSEARCHABLE_USER_TYPE);
+        }
+    }
+
+    /**
+     * 닉네임 중복 체크 (본인 제외)
+     */
+    private void validateNickNameNotDuplicate(Long userId, String nickName) {
+        userRepository.findByNickName(nickName)
+            .filter(existing -> !existing.getUserId().equals(userId))
+            .ifPresent(existing -> {
+                throw new BusinessException(UserErrorCode.DUPLICATE_NICKNAME);
+            });
+    }
+
+    /**
+     * 이메일 중복 체크 (본인 제외)
+     */
+    private void validateEmailNotDuplicate(Long userId, String email) {
+        userRepository.findByEmail(email)
+            .filter(existing -> !existing.getUserId().equals(userId))
+            .ifPresent(existing -> {
+                throw new BusinessException(UserErrorCode.DUPLICATE_EMAIL);
+            });
+    }
+
+    /**
+     * 주소 → 좌표 변환 후 사용자 좌표 업데이트
+     */
+    private void geocodeAndUpdateCoordinates(User user, String address) {
+        GeocodingResult result = geocodingService.geocode(address);
+        if (result.success()) {
+            user.updateCoordinates(result.latitude(), result.longitude());
+            log.info("주소 변경 지오코딩 성공 - userId: {}, 주소: {}", user.getUserId(), address);
+        } else {
+            user.updateCoordinates(null, null);
+            log.warn("주소 변경 지오코딩 실패 - userId: {}, 주소: {}", user.getUserId(), address);
         }
     }
 

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/UserService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/UserService.java
@@ -31,9 +31,6 @@ public class UserService {
     private final FollowRepository followRepository;
     private final GeocodingService geocodingService;
 
-    // ============================================================
-    // 프로필 조회/수정
-    // ============================================================
 
     /**
      * 내 프로필 조회 (전체 정보 포함)
@@ -90,9 +87,6 @@ public class UserService {
         return MyProfileResponseDTO.from(user);
     }
 
-    // ============================================================
-    // 주변 사용자 검색
-    // ============================================================
 
     /**
      * 현재 사용자 기준 주변 사업체(치과, 기공소) 검색
@@ -181,10 +175,6 @@ public class UserService {
             throw new BusinessException(UserErrorCode.GEOCODING_FAILED);
         }
     }
-
-    // ============================================================
-    // Private helpers
-    // ============================================================
 
     private User findUserOrThrow(Long userId) {
         return userRepository.findById(userId)


### PR DESCRIPTION
# 변경사항
- 사용자 프로필 조회 및 수정 기능을 구현했습니다.
- 내 프로필과 타인 프로필을 분리하여 구현했습니다.
- 프로필 부분 수정 패턴을 적용했습니다.

## Entity
- bio : 자기소개글 
- profileImageUrl : 프로필 이미지 url
- update 메서드
- valid 검증 메서드
- 소개글 최대 길이 정의

## ErrorCode
- UserErrorCode 에 새로운 에러 정의

## DTO
- 내 프로필 응답
- 타인 프로필 응답
- 프로필 수정 요청 

## Repository
- 타인 프로필 조회를 위해 팔로우 여부 확인용으로 FollowRepository 추가
- 내 프로필 조회 기능 추가
- 타인 프로필 조회 기능 추가
-  프로필 수정 기능 추가
- 본인 제외 닉네임 중복 검증 기능 추가
- 본인 제외 이메일 중복 검증 기능 추가