### PR TITLE
feat: 피드 작업

### DIFF
--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/FeedController.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/FeedController.java
@@ -1,0 +1,32 @@
+package com.prothsync.prothsync.controller;
+
+import com.prothsync.prothsync.controller.docs.FeedControllerDocs;
+import com.prothsync.prothsync.dto.PostResponseDTO;
+import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.security.CustomUserDetails;
+import com.prothsync.prothsync.service.FeedService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/feed")
+public class FeedController implements FeedControllerDocs {
+
+    private final FeedService feedService;
+
+    @GetMapping
+    public ResponseEntity<PageResponse<PostResponseDTO>> getFollowingFeed(
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        Pageable pageable
+    ) {
+        PageResponse<PostResponseDTO> response = feedService.getFollowingFeed(
+            userDetails.getUserId(), pageable);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/FeedControllerDocs.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/FeedControllerDocs.java
@@ -1,0 +1,41 @@
+package com.prothsync.prothsync.controller.docs;
+
+import com.prothsync.prothsync.dto.PostResponseDTO;
+import com.prothsync.prothsync.exception.ErrorResponse;
+import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "피드", description = "피드 조회 API")
+@SecurityRequirement(name = "bearerAuth")
+public interface FeedControllerDocs {
+
+    @Operation(
+        summary = "팔로잉 피드 조회",
+        description = "현재 사용자가 팔로우한 사용자들의 공개 게시글을 최신순으로 조회합니다. "
+            + "팔로우한 사용자가 없는 경우 빈 결과를 반환합니다."
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "피드 조회 성공"
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description = "인증 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<PageResponse<PostResponseDTO>> getFollowingFeed(
+        CustomUserDetails userDetails,
+        Pageable pageable
+    );
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/global/PageResponse.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/global/PageResponse.java
@@ -14,4 +14,11 @@ public record PageResponse<T>(
             PageableResponse.from(page)
         );
     }
+
+    public static <T> PageResponse<T> empty() {
+        return new PageResponse<>(
+            List.of(),
+            new PageableResponse(0, 0, 0, 0, false, true, true)
+        );
+    }
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/FollowRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/FollowRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.prothsync.prothsync.repository.impl;
 import com.prothsync.prothsync.entity.user.Follow;
 import com.prothsync.prothsync.repository.jpa.FollowJpaRepository;
 import com.prothsync.prothsync.repository.repository.FollowRepository;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -53,5 +54,10 @@ public class FollowRepositoryImpl implements FollowRepository {
     @Override
     public int countByFollowerId(Long followerId) {
         return followJpaRepository.countByFollowerId(followerId);
+    }
+
+    @Override
+    public List<Long> findFollowingIdsByFollowerId(Long followerId) {
+        return followJpaRepository.findFollowingIdsByFollowerId(followerId);
     }
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/PostRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/PostRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.prothsync.prothsync.entity.post.PostCategory;
 import com.prothsync.prothsync.entity.post.PostVisibility;
 import com.prothsync.prothsync.repository.jpa.PostJpaRepository;
 import com.prothsync.prothsync.repository.repository.PostRepository;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -52,5 +53,8 @@ public class PostRepositoryImpl implements PostRepository {
         return postJpaRepository.findAllByUserIdAndVisibility(userId, PostVisibility.PUBLIC, pageable);
     }
 
-
+    @Override
+    public Page<Post> findFeedPostsByUserIds(List<Long> userIds, Pageable pageable) {
+        return postJpaRepository.findAllByUserIdInAndVisibility(userIds, PostVisibility.PUBLIC, pageable);
+    }
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/FollowJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/FollowJpaRepository.java
@@ -1,10 +1,13 @@
 package com.prothsync.prothsync.repository.jpa;
 
 import com.prothsync.prothsync.entity.user.Follow;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface FollowJpaRepository extends JpaRepository<Follow, Long> {
 
@@ -19,4 +22,7 @@ public interface FollowJpaRepository extends JpaRepository<Follow, Long> {
     int countByFollowingId(Long followingId);
 
     int countByFollowerId(Long followerId);
+
+    @Query("SELECT f.followingId FROM Follow f WHERE f.followerId = :followerId")
+    List<Long> findFollowingIdsByFollowerId(@Param("followerId") Long followerId);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/PostJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/PostJpaRepository.java
@@ -3,9 +3,12 @@ package com.prothsync.prothsync.repository.jpa;
 import com.prothsync.prothsync.entity.post.Post;
 import com.prothsync.prothsync.entity.post.PostCategory;
 import com.prothsync.prothsync.entity.post.PostVisibility;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PostJpaRepository extends JpaRepository<Post, Long> {
     Page<Post> findAllByVisibility(PostVisibility visibility, Pageable pageable);
@@ -16,4 +19,10 @@ public interface PostJpaRepository extends JpaRepository<Post, Long> {
 
     Page<Post> findAllByUserIdAndVisibility(Long userId, PostVisibility visibility, Pageable pageable);
 
+    @Query("SELECT p FROM Post p WHERE p.userId IN :userIds AND p.visibility = :visibility ORDER BY p.createdAt DESC")
+    Page<Post> findAllByUserIdInAndVisibility(
+        @Param("userIds") List<Long> userIds,
+        @Param("visibility") PostVisibility visibility,
+        Pageable pageable
+    );
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/FollowRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/FollowRepository.java
@@ -1,6 +1,7 @@
 package com.prothsync.prothsync.repository.repository;
 
 import com.prothsync.prothsync.entity.user.Follow;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -22,4 +23,6 @@ public interface FollowRepository {
     int countByFollowingId(Long followingId);
 
     int countByFollowerId(Long followerId);
+
+    List<Long> findFollowingIdsByFollowerId(Long followerId);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/PostRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/PostRepository.java
@@ -2,6 +2,7 @@ package com.prothsync.prothsync.repository.repository;
 
 import com.prothsync.prothsync.entity.post.Post;
 import com.prothsync.prothsync.entity.post.PostCategory;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -19,5 +20,5 @@ public interface PostRepository {
 
     Page<Post> findAllByUserIdAndVisibilityPublic(Long userId, Pageable pageable);
 
-
+    Page<Post> findFeedPostsByUserIds(List<Long> userIds, Pageable pageable);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/FeedService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/FeedService.java
@@ -1,0 +1,53 @@
+package com.prothsync.prothsync.service;
+
+import com.prothsync.prothsync.dto.HashtagResponseDTO;
+import com.prothsync.prothsync.dto.PostImageResponseDTO;
+import com.prothsync.prothsync.dto.PostResponseDTO;
+import com.prothsync.prothsync.entity.post.Post;
+import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.repository.repository.FollowRepository;
+import com.prothsync.prothsync.repository.repository.PostLikeRepository;
+import com.prothsync.prothsync.repository.repository.PostRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FeedService {
+
+    private final FollowRepository followRepository;
+    private final PostRepository postRepository;
+    private final PostImageService postImageService;
+    private final HashtagService hashtagService;
+    private final PostLikeRepository postLikeRepository;
+
+    @Transactional(readOnly = true)
+    public PageResponse<PostResponseDTO> getFollowingFeed(Long userId, Pageable pageable) {
+        List<Long> followingIds = followRepository.findFollowingIdsByFollowerId(userId);
+
+        if (followingIds.isEmpty()) {
+            return PageResponse.empty();
+        }
+
+        Page<Post> postPage = postRepository.findFeedPostsByUserIds(followingIds, pageable);
+
+        List<PostResponseDTO> feedPosts = postPage.getContent().stream()
+            .map(post -> buildPostResponseDTO(post, userId))
+            .toList();
+
+        return PageResponse.of(feedPosts, postPage);
+    }
+
+    private PostResponseDTO buildPostResponseDTO(Post post, Long currentUserId) {
+        List<PostImageResponseDTO> imageDtos = postImageService.getImagesByPostId(post.getPostId());
+        List<HashtagResponseDTO> hashtagDtos = hashtagService.getHashtagsByPostId(post.getPostId());
+        boolean isLiked = currentUserId != null
+            && postLikeRepository.existsByUserIdAndPostId(currentUserId, post.getPostId());
+
+        return PostResponseDTO.of(post, imageDtos, hashtagDtos, isLiked);
+    }
+}


### PR DESCRIPTION
# 변경사항
- 로그인한 사용자가 자신이 팔로우한 사용자들의 게시글을 최신순으로 조회할 수 있는 팔로잉 피드 기능을 구현했습니다.
- 인스타그램의 피드 와 동일한 개념으로 우선은 내가 팔로우한 사람들의 공개 게시글만 시간역순으로 보여주는 API 입니다.
- 추후에 심화 작업 시 redis등 별도의 인프라를 이용해 수정할 생각도 있습니다.

## 설계 의사 결정
- 보통 피드에 **pull** 방식과 **push** 방식 이렇게 크게 두가지 방식이 있으나
- 저는 pull 방식을 채택하였습니다.

### pull 방식 채택 이유
- 우선 mvp 단계에서 별도의 인프라 redis나 기타 등등 없이 기존 post, follow 테이블만으로 구현이 가능하고
- 데이터 정합성이 자동으로 보장됩니다.
- 그리고 업계 사용 으로 규모가 제한적으로 pull 방식으로도 충분하다고 생각이 들었고 추후에 성능 문제시 push로 변경 예정입니다.

## FeedService 분리
- 피드 조회 로직을 PostService에 넣지 않고 별도 FeedSerivce로 분리하였습니다.
- 이유는 피드와 게시글을 두 도메인을 조합하는 로직이므로, 하나의 서비스에 종속시키면 도메인 간 결합도가 높아진다고 생각이 들었기 때문입니다.
- 결론: Post는 CRUD에 집중하고 Feed는 피드에 집중하는 SRP 원칙에 적합하다고 생각합니다.

