### PR TITLE
feat: 해시태그,게시글,유저 검색 기능 구현

### DIFF
--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/SearchController.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/SearchController.java
@@ -1,0 +1,53 @@
+package com.prothsync.prothsync.controller;
+
+import com.prothsync.prothsync.controller.docs.SearchControllerDocs;
+import com.prothsync.prothsync.dto.HashtagResponseDTO;
+import com.prothsync.prothsync.dto.PostSummaryResponseDTO;
+import com.prothsync.prothsync.dto.UserSearchResponseDTO;
+import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.service.SearchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/search")
+public class SearchController implements SearchControllerDocs {
+
+    private final SearchService searchService;
+
+    @Override
+    @GetMapping("/hashtags")
+    public ResponseEntity<PageResponse<HashtagResponseDTO>> searchHashtags(
+        @RequestParam String keyword,
+        Pageable pageable
+    ) {
+        PageResponse<HashtagResponseDTO> response = searchService.searchHashtags(keyword, pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    @GetMapping("/posts")
+    public ResponseEntity<PageResponse<PostSummaryResponseDTO>> searchPostsByHashtag(
+        @RequestParam String hashtag,
+        Pageable pageable
+    ) {
+        PageResponse<PostSummaryResponseDTO> response = searchService.searchPostsByHashtag(hashtag, pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    @GetMapping("/users")
+    public ResponseEntity<PageResponse<UserSearchResponseDTO>> searchUsers(
+        @RequestParam String keyword,
+        Pageable pageable
+    ) {
+        PageResponse<UserSearchResponseDTO> response = searchService.searchUsers(keyword, pageable);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/SearchControllerDocs.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/SearchControllerDocs.java
@@ -1,0 +1,57 @@
+package com.prothsync.prothsync.controller.docs;
+
+import com.prothsync.prothsync.dto.HashtagResponseDTO;
+import com.prothsync.prothsync.dto.PostSummaryResponseDTO;
+import com.prothsync.prothsync.dto.UserSearchResponseDTO;
+import com.prothsync.prothsync.global.PageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "검색", description = "해시태그 및 사용자 검색 API")
+public interface SearchControllerDocs {
+
+    @Operation(
+        summary = "해시태그 자동완성 검색",
+        description = "키워드로 시작하는 해시태그를 사용량 순으로 조회합니다. '#' 접두사는 자동으로 제거됩니다."
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "검색 성공"),
+        @ApiResponse(responseCode = "400", description = "검색 키워드가 비어있거나 너무 깁니다")
+    })
+    ResponseEntity<PageResponse<HashtagResponseDTO>> searchHashtags(
+        @Parameter(description = "검색 키워드 (예: 임플, 크라운)", required = true) String keyword,
+        Pageable pageable
+    );
+
+    @Operation(
+        summary = "해시태그로 게시물 검색",
+        description = "특정 해시태그가 달린 공개 게시물을 최신순으로 조회합니다. '#' 접두사는 자동으로 제거됩니다."
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "검색 성공"),
+        @ApiResponse(responseCode = "400", description = "검색 키워드가 비어있거나 너무 깁니다"),
+        @ApiResponse(responseCode = "404", description = "해당 해시태그가 존재하지 않습니다")
+    })
+    ResponseEntity<PageResponse<PostSummaryResponseDTO>> searchPostsByHashtag(
+        @Parameter(description = "해시태그 이름 (예: 임플란트, 크라운)", required = true) String hashtag,
+        Pageable pageable
+    );
+
+    @Operation(
+        summary = "사용자 닉네임 검색",
+        description = "닉네임에 키워드가 포함된 사용자를 조회합니다. 대소문자를 구분하지 않습니다."
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "검색 성공"),
+        @ApiResponse(responseCode = "400", description = "검색 키워드가 비어있거나 너무 깁니다")
+    })
+    ResponseEntity<PageResponse<UserSearchResponseDTO>> searchUsers(
+        @Parameter(description = "검색 키워드 (닉네임)", required = true) String keyword,
+        Pageable pageable
+    );
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/dto/UserSearchResponseDTO.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/dto/UserSearchResponseDTO.java
@@ -1,0 +1,25 @@
+package com.prothsync.prothsync.dto;
+
+import com.prothsync.prothsync.entity.user.User;
+import com.prothsync.prothsync.entity.user.UserType;
+
+public record UserSearchResponseDTO(
+    Long userId,
+    String nickName,
+    String profileImageUrl,
+    UserType userType,
+    String bio,
+    int followerCount
+) {
+
+    public static UserSearchResponseDTO from(User user) {
+        return new UserSearchResponseDTO(
+            user.getUserId(),
+            user.getNickName(),
+            user.getProfileImageUrl(),
+            user.getUserType(),
+            user.getBio(),
+            user.getFollowerCount()
+        );
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/exception/SearchErrorCode.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/exception/SearchErrorCode.java
@@ -1,0 +1,18 @@
+package com.prothsync.prothsync.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum SearchErrorCode implements ErrorCode {
+
+    SEARCH_KEYWORD_EMPTY(HttpStatus.BAD_REQUEST, "검색 키워드는 필수입니다."),
+    SEARCH_KEYWORD_TOO_SHORT(HttpStatus.BAD_REQUEST, "검색 키워드는 최소 1자 이상이어야 합니다."),
+    SEARCH_KEYWORD_TOO_LONG(HttpStatus.BAD_REQUEST, "검색 키워드는 최대 50자까지 가능합니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/HashtagRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/HashtagRepositoryImpl.java
@@ -6,6 +6,8 @@ import com.prothsync.prothsync.repository.repository.HashtagRepository;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -42,5 +44,10 @@ public class HashtagRepositoryImpl implements HashtagRepository {
     @Override
     public boolean existsByTagName(String tagName) {
         return hashtagJpaRepository.existsByTagName(tagName);
+    }
+
+    @Override
+    public Page<Hashtag> searchByTagNamePrefix(String keyword, Pageable pageable) {
+        return hashtagJpaRepository.findByTagNameStartingWithOrderByUsageCountDesc(keyword, pageable);
     }
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/PostRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/PostRepositoryImpl.java
@@ -57,4 +57,9 @@ public class PostRepositoryImpl implements PostRepository {
     public Page<Post> findFeedPostsByUserIds(List<Long> userIds, Pageable pageable) {
         return postJpaRepository.findAllByUserIdInAndVisibility(userIds, PostVisibility.PUBLIC, pageable);
     }
+
+    @Override
+    public Page<Post> findAllByHashtagIdAndVisibilityPublic(Long hashtagId, Pageable pageable) {
+        return postJpaRepository.findAllByHashtagIdAndVisibilityPublic(hashtagId, pageable);
+    }
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/UserRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/UserRepositoryImpl.java
@@ -6,6 +6,8 @@ import com.prothsync.prothsync.repository.repository.UserRepository;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -66,5 +68,10 @@ public class UserRepositoryImpl implements UserRepository {
         Long excludeUserId, String userType, int limit) {
         return userJpaRepository.findNearbyUsersByType(lat, lng, radiusKm, excludeUserId,
             userType, limit);
+    }
+
+    @Override
+    public Page<User> searchByNickName(String keyword, Pageable pageable) {
+        return userJpaRepository.findByNickNameContainingIgnoreCase(keyword, pageable);
     }
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/HashtagJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/HashtagJpaRepository.java
@@ -3,6 +3,8 @@ package com.prothsync.prothsync.repository.jpa;
 import com.prothsync.prothsync.entity.post.Hashtag;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,4 +19,6 @@ public interface HashtagJpaRepository extends JpaRepository<Hashtag, Long> {
 
     @Query("SELECT h FROM Hashtag h ORDER BY h.usageCount DESC LIMIT :limit")
     List<Hashtag> findTopByUsageCount(@Param("limit") int limit);
+
+    Page<Hashtag> findByTagNameStartingWithOrderByUsageCountDesc(String keyword, Pageable pageable);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/PostJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/PostJpaRepository.java
@@ -25,4 +25,14 @@ public interface PostJpaRepository extends JpaRepository<Post, Long> {
         @Param("visibility") PostVisibility visibility,
         Pageable pageable
     );
+
+    @Query("""
+        SELECT p FROM Post p
+        WHERE p.postId IN (
+            SELECT ph.postId FROM PostHashtag ph WHERE ph.hashtagId = :hashtagId
+        ) AND p.visibility = 'PUBLIC'
+        ORDER BY p.createdAt DESC
+        """)
+    Page<Post> findAllByHashtagIdAndVisibilityPublic(
+        @Param("hashtagId") Long hashtagId, Pageable pageable);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/UserJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/UserJpaRepository.java
@@ -3,6 +3,8 @@ package com.prothsync.prothsync.repository.jpa;
 import com.prothsync.prothsync.entity.user.User;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -98,4 +100,6 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
         @Param("userType") String userType,
         @Param("limit") int limit
     );
+
+    Page<User> findByNickNameContainingIgnoreCase(String keyword, Pageable pageable);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/HashtagRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/HashtagRepository.java
@@ -3,6 +3,8 @@ package com.prothsync.prothsync.repository.repository;
 import com.prothsync.prothsync.entity.post.Hashtag;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface HashtagRepository {
 
@@ -17,4 +19,6 @@ public interface HashtagRepository {
     List<Hashtag> findTopByUsageCount(int limit);
 
     boolean existsByTagName(String tagName);
+
+    Page<Hashtag> searchByTagNamePrefix(String keyword, Pageable pageable);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/PostRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/PostRepository.java
@@ -21,4 +21,6 @@ public interface PostRepository {
     Page<Post> findAllByUserIdAndVisibilityPublic(Long userId, Pageable pageable);
 
     Page<Post> findFeedPostsByUserIds(List<Long> userIds, Pageable pageable);
+
+    Page<Post> findAllByHashtagIdAndVisibilityPublic(Long hashtagId, Pageable pageable);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/UserRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/UserRepository.java
@@ -3,6 +3,8 @@ package com.prothsync.prothsync.repository.repository;
 import com.prothsync.prothsync.entity.user.User;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface UserRepository {
 
@@ -19,4 +21,6 @@ public interface UserRepository {
         Long excludeUserId, List<String> searchableTypes, int limit);
     List<User> findNearbyUsersByType(double lat, double lng, double radiusKm,
         Long excludeUserId, String userType, int limit);
+
+    Page<User> searchByNickName(String keyword, Pageable pageable);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/SearchService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/SearchService.java
@@ -1,0 +1,109 @@
+package com.prothsync.prothsync.service;
+
+import com.prothsync.prothsync.dto.HashtagResponseDTO;
+import com.prothsync.prothsync.dto.PostSummaryResponseDTO;
+import com.prothsync.prothsync.dto.UserSearchResponseDTO;
+import com.prothsync.prothsync.entity.post.Hashtag;
+import com.prothsync.prothsync.entity.post.Post;
+import com.prothsync.prothsync.entity.user.User;
+import com.prothsync.prothsync.exception.BusinessException;
+import com.prothsync.prothsync.exception.PostErrorCode;
+import com.prothsync.prothsync.exception.SearchErrorCode;
+import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.repository.repository.HashtagRepository;
+import com.prothsync.prothsync.repository.repository.PostRepository;
+import com.prothsync.prothsync.repository.repository.UserRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SearchService {
+
+    private static final int MAX_KEYWORD_LENGTH = 50;
+
+    private final HashtagRepository hashtagRepository;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+    private final PostImageService postImageService;
+
+    /**
+     * 해시태그 자동완성 검색
+     * 접두사(StartingWith) 기반으로 매칭되는 해시태그를 usageCount 내림차순으로 반환
+     */
+    public PageResponse<HashtagResponseDTO> searchHashtags(String keyword, Pageable pageable) {
+        validateKeyword(keyword);
+
+        String normalizedKeyword = normalizeHashtagKeyword(keyword);
+        Page<Hashtag> hashtagPage = hashtagRepository.searchByTagNamePrefix(normalizedKeyword, pageable);
+
+        List<HashtagResponseDTO> hashtags = hashtagPage.getContent().stream()
+            .map(HashtagResponseDTO::from)
+            .toList();
+
+        return PageResponse.of(hashtags, hashtagPage);
+    }
+
+    /**
+     * 해시태그 기반 게시물 검색
+     * 해시태그 이름 → 해시태그 ID 변환 → 해당 해시태그가 달린 PUBLIC 게시물 조회
+     */
+    public PageResponse<PostSummaryResponseDTO> searchPostsByHashtag(String hashtagName, Pageable pageable) {
+        validateKeyword(hashtagName);
+
+        String normalizedName = normalizeHashtagKeyword(hashtagName);
+
+        Hashtag hashtag = hashtagRepository.findByTagName(normalizedName)
+            .orElseThrow(() -> new BusinessException(PostErrorCode.HASHTAG_NOT_FOUND));
+
+        Page<Post> postPage = postRepository.findAllByHashtagIdAndVisibilityPublic(
+            hashtag.getHashtagId(), pageable);
+
+        List<PostSummaryResponseDTO> summaries = postPage.getContent().stream()
+            .map(post -> PostSummaryResponseDTO.of(
+                post, postImageService.getThumbnailUrl(post.getPostId())))
+            .toList();
+
+        return PageResponse.of(summaries, postPage);
+    }
+
+    /**
+     * 사용자 닉네임 검색
+     * 포함(Containing) 기반, 대소문자 무시
+     */
+    public PageResponse<UserSearchResponseDTO> searchUsers(String keyword, Pageable pageable) {
+        validateKeyword(keyword);
+
+        Page<User> userPage = userRepository.searchByNickName(keyword.trim(), pageable);
+
+        List<UserSearchResponseDTO> users = userPage.getContent().stream()
+            .map(UserSearchResponseDTO::from)
+            .toList();
+
+        return PageResponse.of(users, userPage);
+    }
+
+    private void validateKeyword(String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            throw new BusinessException(SearchErrorCode.SEARCH_KEYWORD_EMPTY);
+        }
+        if (keyword.trim().length() > MAX_KEYWORD_LENGTH) {
+            throw new BusinessException(SearchErrorCode.SEARCH_KEYWORD_TOO_LONG);
+        }
+    }
+
+    /**
+     * 해시태그 키워드 정규화
+     * '#' 접두사 제거 및 소문자 변환 (Hashtag 엔티티의 정규화 로직과 동일)
+     */
+    private String normalizeHashtagKeyword(String keyword) {
+        return keyword.trim()
+            .replaceAll("^#+", "")
+            .toLowerCase();
+    }
+}


### PR DESCRIPTION
# 변경사항
- 해시태그 자동완성, 해시태그 기반 게시물 검색, 사용자 닉네임 검색 기능을 구현했습니다.
- 검색 관련 API를 통합한 SearchController로 묶어 클라이언트에서 일관된 검색 엔드포인트를 제공합니다.!

## 주요기능

### 1. 해시태그 자동완성 검색
- 키워드를 시작하는 해시태그를 사용량 usageCount 내림차순으로 조회
- 접두사 startsWith 기반 검색으로 인덱스 활용 가능
- *#*접두사 자동 제거 및 소문자 정규화 처리

### 2. 해시태그 기반 게시물 검색
- 해시태그 이름 -> 해시태그 아이디 변환 -> 게시글 해시태그 서브쿼리로 게시물 조회
- public 상태인 게시물만 노출, 최신순 으로 정렬

### 3. 사용자 닉네임 검색
- 포함 기반 검색, 대소문자 무시
- 검색 결과 전용 DTO로 필요한 정보만 반환