### PR TITLE
feat: 알림 서비스 구현

### DIFF
--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/NotificationController.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/NotificationController.java
@@ -1,0 +1,69 @@
+package com.prothsync.prothsync.controller;
+
+import com.prothsync.prothsync.controller.docs.NotificationControllerDocs;
+import com.prothsync.prothsync.dto.NotificationResponseDTO;
+import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.security.CustomUserDetails;
+import com.prothsync.prothsync.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notifications")
+public class NotificationController implements NotificationControllerDocs {
+
+    private final NotificationService notificationService;
+
+    @GetMapping
+    public ResponseEntity<PageResponse<NotificationResponseDTO>> getMyNotifications(
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        Pageable pageable
+    ) {
+        PageResponse<NotificationResponseDTO> response =
+            notificationService.getMyNotifications(userDetails.getUserId(), pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/unread-count")
+    public ResponseEntity<Integer> getUnreadCount(
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        int count = notificationService.getUnreadCount(userDetails.getUserId());
+        return ResponseEntity.ok(count);
+    }
+
+    @PatchMapping("/{notificationId}/read")
+    public ResponseEntity<Void> markAsRead(
+        @PathVariable Long notificationId,
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        notificationService.markAsRead(notificationId, userDetails.getUserId());
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/read-all")
+    public ResponseEntity<Integer> markAllAsRead(
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        int count = notificationService.markAllAsRead(userDetails.getUserId());
+        return ResponseEntity.ok(count);
+    }
+
+    @DeleteMapping("/{notificationId}")
+    public ResponseEntity<Void> deleteNotification(
+        @PathVariable Long notificationId,
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        notificationService.deleteNotification(notificationId, userDetails.getUserId());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/NotificationControllerDocs.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/NotificationControllerDocs.java
@@ -1,0 +1,85 @@
+package com.prothsync.prothsync.controller.docs;
+
+import com.prothsync.prothsync.dto.NotificationResponseDTO;
+import com.prothsync.prothsync.exception.ErrorResponse;
+import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "알림", description = "알림 API")
+@SecurityRequirement(name = "bearerAuth")
+public interface NotificationControllerDocs {
+
+    @Operation(summary = "내 알림 목록 조회", description = "현재 사용자의 알림 목록을 최신순으로 페이징 조회합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공"),
+        @ApiResponse(
+            responseCode = "401",
+            description = "인증 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<PageResponse<NotificationResponseDTO>> getMyNotifications(
+        CustomUserDetails userDetails,
+        Pageable pageable
+    );
+
+    @Operation(summary = "읽지 않은 알림 수 조회", description = "현재 사용자의 읽지 않은 알림 수를 반환합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    ResponseEntity<Integer> getUnreadCount(CustomUserDetails userDetails);
+
+    @Operation(summary = "개별 알림 읽음 처리", description = "특정 알림을 읽음 상태로 변경합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "읽음 처리 성공"),
+        @ApiResponse(
+            responseCode = "403",
+            description = "알림에 접근할 권한이 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "알림을 찾을 수 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<Void> markAsRead(
+        @Parameter(description = "알림 ID") Long notificationId,
+        CustomUserDetails userDetails
+    );
+
+    @Operation(summary = "전체 알림 읽음 처리", description = "현재 사용자의 모든 알림을 읽음 상태로 변경합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "전체 읽음 처리 성공")
+    })
+    ResponseEntity<Integer> markAllAsRead(CustomUserDetails userDetails);
+
+    @Operation(summary = "알림 삭제", description = "특정 알림을 삭제합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "삭제 성공"),
+        @ApiResponse(
+            responseCode = "403",
+            description = "알림에 접근할 권한이 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "알림을 찾을 수 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<Void> deleteNotification(
+        @Parameter(description = "알림 ID") Long notificationId,
+        CustomUserDetails userDetails
+    );
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/dto/NotificationResponseDTO.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/dto/NotificationResponseDTO.java
@@ -1,0 +1,49 @@
+package com.prothsync.prothsync.dto;
+
+import com.prothsync.prothsync.entity.notification.Notification;
+import com.prothsync.prothsync.entity.notification.NotificationType;
+import com.prothsync.prothsync.entity.notification.ReferenceType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "알림 응답 DTO")
+public record NotificationResponseDTO(
+
+    @Schema(description = "알림 ID")
+    Long notificationId,
+
+    @Schema(description = "알림 발생자 ID")
+    Long actorId,
+
+    @Schema(description = "알림 타입")
+    NotificationType type,
+
+    @Schema(description = "참조 엔티티 ID")
+    Long referenceId,
+
+    @Schema(description = "참조 엔티티 타입")
+    ReferenceType referenceType,
+
+    @Schema(description = "알림 메시지")
+    String message,
+
+    @Schema(description = "읽음 여부")
+    boolean isRead,
+
+    @Schema(description = "생성일시")
+    LocalDateTime createdAt
+) {
+
+    public static NotificationResponseDTO from(Notification notification) {
+        return new NotificationResponseDTO(
+            notification.getNotificationId(),
+            notification.getActorId(),
+            notification.getType(),
+            notification.getReferenceId(),
+            notification.getReferenceType(),
+            notification.getMessage(),
+            notification.isRead(),
+            notification.getCreatedAt()
+        );
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/notification/Notification.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/notification/Notification.java
@@ -1,0 +1,105 @@
+package com.prothsync.prothsync.entity.notification;
+
+import com.prothsync.prothsync.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+    name = "notifications",
+    indexes = {
+        @Index(name = "idx_notification_recipient", columnList = "recipient_id, is_read, created_at")
+    }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long notificationId;
+
+    @Column(name = "recipient_id", nullable = false)
+    private Long recipientId;
+
+    @Column(name = "actor_id", nullable = false)
+    private Long actorId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private NotificationType type;
+
+    @Column(name = "reference_id")
+    private Long referenceId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reference_type", length = 20)
+    private ReferenceType referenceType;
+
+    @Column(nullable = false)
+    private String message;
+
+    @Column(name = "is_read", nullable = false)
+    private boolean isRead;
+
+    private Notification(Long recipientId, Long actorId, NotificationType type,
+        Long referenceId, ReferenceType referenceType, String message) {
+        this.recipientId = recipientId;
+        this.actorId = actorId;
+        this.type = type;
+        this.referenceId = referenceId;
+        this.referenceType = referenceType;
+        this.message = message;
+        this.isRead = false;
+    }
+
+    public static Notification create(Long recipientId, Long actorId, NotificationType type,
+        Long referenceId, ReferenceType referenceType, String message) {
+        validateRecipientId(recipientId);
+        validateActorId(actorId);
+        validateType(type);
+        validateMessage(message);
+
+        return new Notification(recipientId, actorId, type, referenceId, referenceType, message);
+    }
+
+    public void markAsRead() {
+        this.isRead = true;
+    }
+
+    // === Validation ===
+
+    private static void validateRecipientId(Long recipientId) {
+        if (recipientId == null) {
+            throw new IllegalArgumentException("알림 수신자 ID는 필수입니다.");
+        }
+    }
+
+    private static void validateActorId(Long actorId) {
+        if (actorId == null) {
+            throw new IllegalArgumentException("알림 발생자 ID는 필수입니다.");
+        }
+    }
+
+    private static void validateType(NotificationType type) {
+        if (type == null) {
+            throw new IllegalArgumentException("알림 타입은 필수입니다.");
+        }
+    }
+
+    private static void validateMessage(String message) {
+        if (message == null || message.isBlank()) {
+            throw new IllegalArgumentException("알림 메시지는 필수입니다.");
+        }
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/notification/NotificationType.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/notification/NotificationType.java
@@ -1,0 +1,22 @@
+package com.prothsync.prothsync.entity.notification;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationType {
+
+    LIKE("님이 게시글에 좋아요를 눌렀습니다."),
+    COMMENT("님이 게시글에 댓글을 남겼습니다."),
+    FOLLOW("님이 회원님을 팔로우했습니다."),
+
+    PROPOSAL_RECEIVED("님이 의뢰에 제안을 보냈습니다."),
+    PROPOSAL_ACCEPTED("님이 제안을 수락했습니다."),
+    PROPOSAL_REJECTED("님이 제안을 거절했습니다."),
+    CASE_IN_PROGRESS("의뢰가 진행 중으로 변경되었습니다."),
+    CASE_COMPLETED("의뢰가 완료되었습니다."),
+    CASE_CANCELLED("의뢰가 취소되었습니다.");
+
+    private final String message;
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/notification/ReferenceType.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/notification/ReferenceType.java
@@ -1,0 +1,9 @@
+package com.prothsync.prothsync.entity.notification;
+
+public enum ReferenceType {
+    POST,
+    COMMENT,
+    CASE_REQUEST,
+    CASE_PROPOSAL,
+    USER
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/exception/NotificationErrorCode.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/exception/NotificationErrorCode.java
@@ -1,0 +1,20 @@
+package com.prothsync.prothsync.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationErrorCode implements ErrorCode {
+
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "알림을 찾을 수 없습니다."),
+    NOTIFICATION_ACCESS_DENIED(HttpStatus.FORBIDDEN, "알림에 접근할 권한이 없습니다."),
+    NOTIFICATION_RECIPIENT_NULL(HttpStatus.BAD_REQUEST, "알림 수신자 ID는 필수입니다."),
+    NOTIFICATION_ACTOR_NULL(HttpStatus.BAD_REQUEST, "알림 발생자 ID는 필수입니다."),
+    NOTIFICATION_TYPE_NULL(HttpStatus.BAD_REQUEST, "알림 타입은 필수입니다."),
+    NOTIFICATION_MESSAGE_NULL(HttpStatus.BAD_REQUEST, "알림 메시지는 필수입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/NotificationRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/NotificationRepositoryImpl.java
@@ -1,0 +1,48 @@
+package com.prothsync.prothsync.repository.impl;
+
+import com.prothsync.prothsync.entity.notification.Notification;
+import com.prothsync.prothsync.repository.jpa.NotificationJpaRepository;
+import com.prothsync.prothsync.repository.repository.NotificationRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationRepositoryImpl implements NotificationRepository {
+
+    private final NotificationJpaRepository notificationJpaRepository;
+
+    @Override
+    public Notification save(Notification notification) {
+        return notificationJpaRepository.save(notification);
+    }
+
+    @Override
+    public Optional<Notification> findById(Long notificationId) {
+        return notificationJpaRepository.findById(notificationId);
+    }
+
+    @Override
+    public Page<Notification> findByRecipientId(Long recipientId, Pageable pageable) {
+        return notificationJpaRepository.findByRecipientIdAndDeletedAtIsNullOrderByCreatedAtDesc(
+            recipientId, pageable);
+    }
+
+    @Override
+    public int countUnreadByRecipientId(Long recipientId) {
+        return notificationJpaRepository.countByRecipientIdAndIsReadFalseAndDeletedAtIsNull(recipientId);
+    }
+
+    @Override
+    public int markAllAsRead(Long recipientId) {
+        return notificationJpaRepository.markAllAsRead(recipientId);
+    }
+
+    @Override
+    public void delete(Notification notification) {
+        notificationJpaRepository.delete(notification);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/NotificationJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/NotificationJpaRepository.java
@@ -1,0 +1,21 @@
+package com.prothsync.prothsync.repository.jpa;
+
+import com.prothsync.prothsync.entity.notification.Notification;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface NotificationJpaRepository extends JpaRepository<Notification, Long> {
+
+    Page<Notification> findByRecipientIdAndDeletedAtIsNullOrderByCreatedAtDesc(
+        Long recipientId, Pageable pageable);
+
+    int countByRecipientIdAndIsReadFalseAndDeletedAtIsNull(Long recipientId);
+
+    @Modifying
+    @Query("UPDATE Notification n SET n.isRead = true WHERE n.recipientId = :recipientId AND n.isRead = false AND n.deletedAt IS NULL")
+    int markAllAsRead(@Param("recipientId") Long recipientId);
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/NotificationRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/NotificationRepository.java
@@ -1,0 +1,21 @@
+package com.prothsync.prothsync.repository.repository;
+
+import com.prothsync.prothsync.entity.notification.Notification;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface NotificationRepository {
+
+    Notification save(Notification notification);
+
+    Optional<Notification> findById(Long notificationId);
+
+    Page<Notification> findByRecipientId(Long recipientId, Pageable pageable);
+
+    int countUnreadByRecipientId(Long recipientId);
+
+    int markAllAsRead(Long recipientId);
+
+    void delete(Notification notification);
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/CaseProposalService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/CaseProposalService.java
@@ -5,6 +5,8 @@ import com.prothsync.prothsync.dto.CaseProposalResponseDTO;
 import com.prothsync.prothsync.entity.caserequest.CaseProposal;
 import com.prothsync.prothsync.entity.caserequest.CaseRequest;
 import com.prothsync.prothsync.entity.caserequest.ProposalStatus;
+import com.prothsync.prothsync.entity.notification.NotificationType;
+import com.prothsync.prothsync.entity.notification.ReferenceType;
 import com.prothsync.prothsync.exception.BusinessException;
 import com.prothsync.prothsync.exception.CaseErrorCode;
 import com.prothsync.prothsync.exception.UserErrorCode;
@@ -26,6 +28,7 @@ public class CaseProposalService {
     private final CaseProposalRepository caseProposalRepository;
     private final CaseRequestRepository caseRequestRepository;
     private final UserRepository userRepository;
+    private final NotificationService notificationService;
 
     @Transactional
     public CaseProposalResponseDTO createProposal(
@@ -50,6 +53,10 @@ public class CaseProposalService {
 
         caseRequest.incrementProposalCount();
         caseRequestRepository.save(caseRequest);
+
+        notificationService.send(
+            NotificationType.PROPOSAL_RECEIVED, proposerId, caseRequest.getClientId(),
+            caseRequestId, ReferenceType.CASE_REQUEST);
 
         return CaseProposalResponseDTO.from(saved);
     }
@@ -89,6 +96,10 @@ public class CaseProposalService {
         caseRequest.startProgress();
         caseRequestRepository.save(caseRequest);
 
+        notificationService.send(
+            NotificationType.PROPOSAL_ACCEPTED, userId, proposal.getProposerId(),
+            proposalId, ReferenceType.CASE_PROPOSAL);
+
         return CaseProposalResponseDTO.from(proposal);
     }
 
@@ -101,6 +112,10 @@ public class CaseProposalService {
 
         proposal.reject();
         caseProposalRepository.save(proposal);
+
+        notificationService.send(
+            NotificationType.PROPOSAL_REJECTED, userId, proposal.getProposerId(),
+            proposalId, ReferenceType.CASE_PROPOSAL);
 
         return CaseProposalResponseDTO.from(proposal);
     }
@@ -125,6 +140,12 @@ public class CaseProposalService {
 
         caseRequest.complete();
         caseRequestRepository.save(caseRequest);
+
+        caseProposalRepository
+            .findAllByCaseRequestIdAndStatus(caseRequestId, ProposalStatus.ACCEPTED)
+            .forEach(proposal -> notificationService.send(
+                NotificationType.CASE_COMPLETED, userId, proposal.getProposerId(),
+                caseRequestId, ReferenceType.CASE_REQUEST));
     }
 
     private CaseRequest findCaseRequestOrThrow(Long caseRequestId) {

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/CommentService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/CommentService.java
@@ -3,6 +3,8 @@ package com.prothsync.prothsync.service;
 import com.prothsync.prothsync.dto.CommentCreateRequestDTO;
 import com.prothsync.prothsync.dto.CommentResponseDTO;
 import com.prothsync.prothsync.dto.CommentUpdateRequestDTO;
+import com.prothsync.prothsync.entity.notification.NotificationType;
+import com.prothsync.prothsync.entity.notification.ReferenceType;
 import com.prothsync.prothsync.entity.post.Comment;
 import com.prothsync.prothsync.entity.post.Post;
 import com.prothsync.prothsync.exception.BusinessException;
@@ -23,6 +25,7 @@ public class CommentService {
 
     private final CommentRepository commentRepository;
     private final PostRepository postRepository;
+    private final NotificationService notificationService;
 
     @Transactional
     public CommentResponseDTO createComment(Long postId, Long userId, CommentCreateRequestDTO request) {
@@ -33,6 +36,10 @@ public class CommentService {
 
         post.incrementCommentCount();
         postRepository.save(post);
+
+        notificationService.send(
+            NotificationType.COMMENT, userId, post.getUserId(),
+            postId, ReferenceType.POST);
 
         return CommentResponseDTO.from(savedComment);
     }

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/FollowService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/FollowService.java
@@ -2,6 +2,8 @@ package com.prothsync.prothsync.service;
 
 import com.prothsync.prothsync.dto.FollowResponseDTO;
 import com.prothsync.prothsync.dto.FollowUserResponseDTO;
+import com.prothsync.prothsync.entity.notification.NotificationType;
+import com.prothsync.prothsync.entity.notification.ReferenceType;
 import com.prothsync.prothsync.entity.user.Follow;
 import com.prothsync.prothsync.entity.user.User;
 import com.prothsync.prothsync.exception.BusinessException;
@@ -23,6 +25,7 @@ public class FollowService {
 
     private final FollowRepository followRepository;
     private final UserRepository userRepository;
+    private final NotificationService notificationService;
 
     @Transactional
     public FollowResponseDTO toggleFollow(Long followerId, Long followingId) {
@@ -46,6 +49,11 @@ public class FollowService {
             following.incrementFollowerCount();
             userRepository.save(follower);
             userRepository.save(following);
+
+            notificationService.send(
+                NotificationType.FOLLOW, followerId, followingId,
+                followerId, ReferenceType.USER);
+
             return FollowResponseDTO.of(followingId, true, following.getFollowerCount());
         }
     }

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/LikeService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/LikeService.java
@@ -1,6 +1,8 @@
 package com.prothsync.prothsync.service;
 
 import com.prothsync.prothsync.dto.LikeResponseDTO;
+import com.prothsync.prothsync.entity.notification.NotificationType;
+import com.prothsync.prothsync.entity.notification.ReferenceType;
 import com.prothsync.prothsync.entity.post.Post;
 import com.prothsync.prothsync.entity.post.PostLike;
 import com.prothsync.prothsync.exception.BusinessException;
@@ -18,6 +20,7 @@ public class LikeService {
 
     private final PostLikeRepository postLikeRepository;
     private final PostRepository postRepository;
+    private final NotificationService notificationService;
 
     @Transactional
     public LikeResponseDTO toggleLike(Long postId, Long userId) {
@@ -35,6 +38,10 @@ public class LikeService {
             postLikeRepository.save(postLike);
             post.incrementLikeCount();
             postRepository.save(post);
+
+            notificationService.send(
+                NotificationType.LIKE,userId,post.getUserId(),postId, ReferenceType.POST
+            );
             return LikeResponseDTO.of(postId, true, post.getLikeCount());
         }
     }

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/NotificationService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/NotificationService.java
@@ -1,0 +1,97 @@
+package com.prothsync.prothsync.service;
+
+import com.prothsync.prothsync.dto.NotificationResponseDTO;
+import com.prothsync.prothsync.entity.notification.Notification;
+import com.prothsync.prothsync.entity.notification.NotificationType;
+import com.prothsync.prothsync.entity.notification.ReferenceType;
+import com.prothsync.prothsync.exception.BusinessException;
+import com.prothsync.prothsync.exception.NotificationErrorCode;
+import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.repository.repository.NotificationRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+
+    @Transactional
+    public void send(NotificationType type, Long actorId, Long recipientId,
+        Long referenceId, ReferenceType referenceType) {
+        if (actorId.equals(recipientId)) {
+            return;
+        }
+
+        String message = type.getMessage();
+
+        Notification notification = Notification.create(
+            recipientId, actorId, type, referenceId, referenceType, message);
+
+        notificationRepository.save(notification);
+        log.info("알림 생성 - type: {}, actor: {}, recipient: {}", type, actorId, recipientId);
+    }
+
+
+    @Transactional(readOnly = true)
+    public PageResponse<NotificationResponseDTO> getMyNotifications(Long userId, Pageable pageable) {
+        Page<Notification> page = notificationRepository.findByRecipientId(userId, pageable);
+
+        List<NotificationResponseDTO> data = page.getContent().stream()
+            .map(NotificationResponseDTO::from)
+            .toList();
+
+        return PageResponse.of(data, page);
+    }
+
+
+    @Transactional(readOnly = true)
+    public int getUnreadCount(Long userId) {
+        return notificationRepository.countUnreadByRecipientId(userId);
+    }
+
+
+    @Transactional
+    public void markAsRead(Long notificationId, Long userId) {
+        Notification notification = findNotificationOrThrow(notificationId);
+        validateOwner(notification, userId);
+
+        notification.markAsRead();
+        notificationRepository.save(notification);
+    }
+
+
+    @Transactional
+    public int markAllAsRead(Long userId) {
+        return notificationRepository.markAllAsRead(userId);
+    }
+
+
+    @Transactional
+    public void deleteNotification(Long notificationId, Long userId) {
+        Notification notification = findNotificationOrThrow(notificationId);
+        validateOwner(notification, userId);
+
+        notification.delete(userId);
+        notificationRepository.save(notification);
+    }
+
+    private Notification findNotificationOrThrow(Long notificationId) {
+        return notificationRepository.findById(notificationId)
+            .orElseThrow(() -> new BusinessException(NotificationErrorCode.NOTIFICATION_NOT_FOUND));
+    }
+
+    private void validateOwner(Notification notification, Long userId) {
+        if (!notification.getRecipientId().equals(userId)) {
+            throw new BusinessException(NotificationErrorCode.NOTIFICATION_ACCESS_DENIED);
+        }
+    }
+}


### PR DESCRIPTION
# 변경사항
- 사용자 간 상호작용(좋아요, 갯글, 팔로우) 및 비즈니스 이벤트(외주 의뢰/제안)에 대한 알림 기능을 구현합니다.
- 현재 MVP 단계로 DB 저장이랑 간단한 API 폴링 방식으로 구현했으나 추후에 SSE를 통한 실시간 알림 전환을 고려하고 있습니다.

## 설계 결정사항

### 1.  폴링 방식 채택
- 피드 기능과 동일하게 Pull 모델 채택
- 현재 서비스 규모에서 충분한 성능
- 추후 SSE로 전환하여 실시간 알림 지원 예정

### 2. 동기 알림 생성
- 각 Service에서 NotificationService.send()를 직접 호출
- 추후에 @Async 또는 ApplicationEventpulbisher를 통한 비동기 처리로 전환 예정

