### PR TITLE
feat: 리뷰 서비스 구현

### DIFF
--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/ReviewController.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/ReviewController.java
@@ -1,0 +1,72 @@
+package com.prothsync.prothsync.controller;
+
+import com.prothsync.prothsync.controller.docs.ReviewControllerDocs;
+import com.prothsync.prothsync.dto.ReviewCreateRequestDTO;
+import com.prothsync.prothsync.dto.ReviewResponseDTO;
+import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.security.CustomUserDetails;
+import com.prothsync.prothsync.service.ReviewService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class ReviewController implements ReviewControllerDocs {
+
+    private final ReviewService reviewService;
+
+    @PostMapping("/cases/{caseRequestId}/reviews")
+    public ResponseEntity<ReviewResponseDTO> createReview(
+        @PathVariable Long caseRequestId,
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        @Valid @RequestBody ReviewCreateRequestDTO request
+    ) {
+        ReviewResponseDTO response = reviewService.createReview(
+            caseRequestId, userDetails.getUserId(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping("/users/{userId}/reviews")
+    public ResponseEntity<PageResponse<ReviewResponseDTO>> getReviewsByUser(
+        @PathVariable Long userId,
+        Pageable pageable
+    ) {
+        PageResponse<ReviewResponseDTO> response =
+            reviewService.getReviewsByReviewee(userId, pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/reviews/{reviewId}")
+    public ResponseEntity<ReviewResponseDTO> getReview(
+        @PathVariable Long reviewId
+    ) {
+        ReviewResponseDTO response = reviewService.getReview(reviewId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/reviews/{reviewId}")
+    public ResponseEntity<ReviewResponseDTO> updateReview(
+        @PathVariable Long reviewId,
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        @Valid @RequestBody ReviewCreateRequestDTO request
+    ) {
+        ReviewResponseDTO response = reviewService.updateReview(
+            reviewId, userDetails.getUserId(), request);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/reviews/{reviewId}")
+    public ResponseEntity<Void> deleteReview(
+        @PathVariable Long reviewId,
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        reviewService.deleteReview(reviewId, userDetails.getUserId());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/ReviewControllerDocs.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/ReviewControllerDocs.java
@@ -1,0 +1,43 @@
+package com.prothsync.prothsync.controller.docs;
+
+import com.prothsync.prothsync.dto.ReviewCreateRequestDTO;
+import com.prothsync.prothsync.dto.ReviewResponseDTO;
+import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Review", description = "리뷰/평점 관리 API")
+public interface ReviewControllerDocs {
+
+    @Operation(summary = "리뷰 작성", description = "완료된 의뢰에 대해 리뷰를 작성합니다.")
+    @ApiResponse(responseCode = "201", description = "리뷰 생성 성공")
+    @ApiResponse(responseCode = "409", description = "이미 리뷰가 존재하거나 의뢰가 완료 상태가 아님")
+    ResponseEntity<ReviewResponseDTO> createReview(
+        Long caseRequestId, CustomUserDetails userDetails,
+        ReviewCreateRequestDTO request);
+
+    @Operation(summary = "사용자 리뷰 목록 조회",
+        description = "특정 사용자(기공사)가 받은 리뷰 목록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    ResponseEntity<PageResponse<ReviewResponseDTO>> getReviewsByUser(
+        Long userId, Pageable pageable);
+
+    @Operation(summary = "리뷰 단건 조회")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    ResponseEntity<ReviewResponseDTO> getReview(Long reviewId);
+
+    @Operation(summary = "리뷰 수정", description = "본인이 작성한 리뷰를 수정합니다.")
+    @ApiResponse(responseCode = "200", description = "수정 성공")
+    ResponseEntity<ReviewResponseDTO> updateReview(
+        Long reviewId, CustomUserDetails userDetails,
+        ReviewCreateRequestDTO request);
+
+    @Operation(summary = "리뷰 삭제", description = "본인이 작성한 리뷰를 삭제합니다.")
+    @ApiResponse(responseCode = "204", description = "삭제 성공")
+    ResponseEntity<Void> deleteReview(
+        Long reviewId, CustomUserDetails userDetails);
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/dto/MyProfileResponseDTO.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/dto/MyProfileResponseDTO.java
@@ -42,6 +42,12 @@ public record MyProfileResponseDTO(
     @Schema(description = "팔로잉 수")
     int followingCount,
 
+    @Schema(description = "평균 평점")
+    double averageRating,
+
+    @Schema(description = "받은 리뷰 수")
+    int reviewCount,
+
     @Schema(description = "위도")
     Double latitude,
 
@@ -65,6 +71,8 @@ public record MyProfileResponseDTO(
             user.getUserType(),
             user.getFollowerCount(),
             user.getFollowingCount(),
+            user.getAverageRating(),
+            user.getReviewCount(),
             user.getLatitude(),
             user.getLongitude(),
             user.getCreatedAt()

--- a/prothsync/src/main/java/com/prothsync/prothsync/dto/ReviewCreateRequestDTO.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/dto/ReviewCreateRequestDTO.java
@@ -1,0 +1,21 @@
+package com.prothsync.prothsync.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "리뷰 생성 요청 DTO")
+public record ReviewCreateRequestDTO(
+
+    @Schema(description = "평점 (1~5)", example = "5")
+    @NotNull(message = "평점은 필수입니다.")
+    @Min(value = 1, message = "평점은 최소 1점입니다.")
+    @Max(value = 5, message = "평점은 최대 5점입니다.")
+    Integer rating,
+
+    @Schema(description = "리뷰 내용 (최대 500자)", example = "보철물 퀄리티가 매우 좋았습니다.")
+    @Size(max = 500, message = "리뷰 내용은 최대 500자입니다.")
+    String content
+) {}

--- a/prothsync/src/main/java/com/prothsync/prothsync/dto/ReviewResponseDTO.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/dto/ReviewResponseDTO.java
@@ -1,0 +1,42 @@
+package com.prothsync.prothsync.dto;
+
+import com.prothsync.prothsync.entity.review.Review;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "리뷰 응답 DTO")
+public record ReviewResponseDTO(
+
+    @Schema(description = "리뷰 ID")
+    Long reviewId,
+
+    @Schema(description = "의뢰 ID")
+    Long caseRequestId,
+
+    @Schema(description = "작성자 ID")
+    Long reviewerId,
+
+    @Schema(description = "대상자 ID")
+    Long revieweeId,
+
+    @Schema(description = "평점")
+    int rating,
+
+    @Schema(description = "리뷰 내용")
+    String content,
+
+    @Schema(description = "작성일")
+    LocalDateTime createdAt
+) {
+    public static ReviewResponseDTO from(Review review) {
+        return new ReviewResponseDTO(
+            review.getReviewId(),
+            review.getCaseRequestId(),
+            review.getReviewerId(),
+            review.getRevieweeId(),
+            review.getRating(),
+            review.getContent(),
+            review.getCreatedAt()
+        );
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/dto/UserProfileResponseDTO.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/dto/UserProfileResponseDTO.java
@@ -35,6 +35,12 @@ public record UserProfileResponseDTO(
     @Schema(description = "팔로우 여부 (로그인 사용자 기준)")
     boolean isFollowing,
 
+    @Schema(description = "평균 평점")
+    double averageRating,
+
+    @Schema(description = "받은 리뷰 수")
+    int reviewCount,
+
     @Schema(description = "가입일")
     LocalDateTime createdAt
 ) {
@@ -50,6 +56,8 @@ public record UserProfileResponseDTO(
             user.getFollowerCount(),
             user.getFollowingCount(),
             isFollowing,
+            user.getAverageRating(),
+            user.getReviewCount(),
             user.getCreatedAt()
         );
     }

--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/notification/NotificationType.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/notification/NotificationType.java
@@ -10,6 +10,7 @@ public enum NotificationType {
     LIKE("님이 게시글에 좋아요를 눌렀습니다."),
     COMMENT("님이 게시글에 댓글을 남겼습니다."),
     FOLLOW("님이 회원님을 팔로우했습니다."),
+    REVIEW_RECEIVED("님이 리뷰를 작성했습니다."),
 
     PROPOSAL_RECEIVED("님이 의뢰에 제안을 보냈습니다."),
     PROPOSAL_ACCEPTED("님이 제안을 수락했습니다."),

--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/notification/ReferenceType.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/notification/ReferenceType.java
@@ -5,5 +5,6 @@ public enum ReferenceType {
     COMMENT,
     CASE_REQUEST,
     CASE_PROPOSAL,
-    USER
+    USER,
+    REVIEW
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/review/Review.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/review/Review.java
@@ -1,0 +1,113 @@
+package com.prothsync.prothsync.entity.review;
+
+import com.prothsync.prothsync.common.BaseEntity;
+import com.prothsync.prothsync.exception.BusinessException;
+import com.prothsync.prothsync.exception.ReviewErrorCode;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+    name = "reviews",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_reviews_case_request",
+            columnNames = {"case_request_id"}
+        )
+    }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Review extends BaseEntity {
+
+    private static final int MAX_CONTENT_LENGTH = 500;
+    private static final int MIN_RATING = 1;
+    private static final int MAX_RATING = 5;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long reviewId;
+
+    @Column(name = "case_request_id", nullable = false)
+    private Long caseRequestId;
+
+    @Column(name = "reviewer_id", nullable = false)
+    private Long reviewerId;
+
+    @Column(name = "reviewee_id", nullable = false)
+    private Long revieweeId;
+
+    @Column(nullable = false)
+    private int rating;
+
+    @Column(length = 500)
+    private String content;
+
+    private Review(Long caseRequestId, Long reviewerId,
+        Long revieweeId, int rating, String content) {
+        this.caseRequestId = caseRequestId;
+        this.reviewerId = reviewerId;
+        this.revieweeId = revieweeId;
+        this.rating = rating;
+        this.content = content;
+    }
+
+    public static Review create(Long caseRequestId, Long reviewerId,
+        Long revieweeId, int rating, String content) {
+        validateCaseRequestId(caseRequestId);
+        validateReviewerId(reviewerId);
+        validateRevieweeId(revieweeId);
+        validateRating(rating);
+        validateContent(content);
+
+        return new Review(caseRequestId, reviewerId, revieweeId, rating, content);
+    }
+
+
+    private static void validateCaseRequestId(Long caseRequestId) {
+        if (caseRequestId == null) {
+            throw new BusinessException(ReviewErrorCode.REVIEW_CASE_REQUEST_ID_NULL);
+        }
+    }
+
+    private static void validateReviewerId(Long reviewerId) {
+        if (reviewerId == null) {
+            throw new BusinessException(ReviewErrorCode.REVIEW_REVIEWER_ID_NULL);
+        }
+    }
+
+    private static void validateRevieweeId(Long revieweeId) {
+        if (revieweeId == null) {
+            throw new BusinessException(ReviewErrorCode.REVIEW_REVIEWEE_ID_NULL);
+        }
+    }
+
+    private static void validateRating(int rating) {
+        if (rating < MIN_RATING || rating > MAX_RATING) {
+            throw new BusinessException(ReviewErrorCode.REVIEW_RATING_INVALID);
+        }
+    }
+
+    private static void validateContent(String content) {
+        if (content != null && content.length() > MAX_CONTENT_LENGTH) {
+            throw new BusinessException(ReviewErrorCode.REVIEW_CONTENT_TOO_LONG);
+        }
+    }
+
+
+    public void updateContent(String newContent) {
+        validateContent(newContent);
+        this.content = newContent;
+    }
+
+    public void updateRating(int newRating) {
+        validateRating(newRating);
+        this.rating = newRating;
+    }
+
+    public boolean isWrittenBy(Long userId) {
+        return this.reviewerId.equals(userId);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/user/User.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/user/User.java
@@ -76,6 +76,12 @@ public class User extends BaseEntity {
     @Column(length = 500)
     private String profileImageUrl;
 
+    @Column(nullable = false)
+    private double averageRating = 0.0;
+
+    @Column(nullable = false)
+    private int reviewCount = 0;
+
     private User(String userName,
         String password,
         String nickName,
@@ -246,5 +252,10 @@ public class User extends BaseEntity {
 
     public boolean isAdmin() {
         return this.userRole == UserRole.ADMIN;
+    }
+
+    public void updateRatingStats(double averageRating, int reviewCount) {
+        this.averageRating = averageRating;
+        this.reviewCount = reviewCount;
     }
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/exception/ReviewErrorCode.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/exception/ReviewErrorCode.java
@@ -1,0 +1,27 @@
+package com.prothsync.prothsync.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReviewErrorCode implements ErrorCode {
+
+    REVIEW_CASE_REQUEST_ID_NULL(HttpStatus.BAD_REQUEST, "의뢰 ID는 필수입니다."),
+    REVIEW_REVIEWER_ID_NULL(HttpStatus.BAD_REQUEST, "작성자 ID는 필수입니다."),
+    REVIEW_REVIEWEE_ID_NULL(HttpStatus.BAD_REQUEST, "대상자 ID는 필수입니다."),
+    REVIEW_RATING_INVALID(HttpStatus.BAD_REQUEST, "평점은 1~5 사이여야 합니다."),
+    REVIEW_CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "리뷰 내용이 너무 깁니다.(최대 500자)"),
+
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "리뷰를 찾을 수 없습니다."),
+
+    REVIEW_ACCESS_DENIED(HttpStatus.FORBIDDEN, "리뷰에 접근할 권한이 없습니다."),
+    REVIEW_ALREADY_EXISTS(HttpStatus.CONFLICT, "해당 의뢰에 대한 리뷰가 이미 존재합니다."),
+    REVIEW_CASE_NOT_COMPLETED(HttpStatus.CONFLICT, "완료된 의뢰에만 리뷰를 작성할 수 있습니다."),
+    REVIEW_NOT_CLIENT(HttpStatus.FORBIDDEN, "의뢰자만 리뷰를 작성할 수 있습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/ReviewRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/ReviewRepositoryImpl.java
@@ -1,0 +1,52 @@
+package com.prothsync.prothsync.repository.impl;
+
+import com.prothsync.prothsync.entity.review.Review;
+import com.prothsync.prothsync.repository.jpa.ReviewJpaRepository;
+import com.prothsync.prothsync.repository.repository.ReviewRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewRepositoryImpl implements ReviewRepository {
+
+    private final ReviewJpaRepository reviewJpaRepository;
+
+    @Override
+    public Review save(Review review) {
+        return reviewJpaRepository.save(review);
+    }
+
+    @Override
+    public Optional<Review> findById(Long reviewId) {
+        return reviewJpaRepository.findById(reviewId);
+    }
+
+    @Override
+    public void delete(Review review) {
+        reviewJpaRepository.delete(review);
+    }
+
+    @Override
+    public boolean existsByCaseRequestId(Long caseRequestId) {
+        return reviewJpaRepository.existsByCaseRequestId(caseRequestId);
+    }
+
+    @Override
+    public Page<Review> findAllByRevieweeId(Long revieweeId, Pageable pageable) {
+        return reviewJpaRepository.findAllByRevieweeIdOrderByCreatedAtDesc(revieweeId, pageable);
+    }
+
+    @Override
+    public Double findAverageRatingByRevieweeId(Long revieweeId) {
+        return reviewJpaRepository.findAverageRatingByRevieweeId(revieweeId);
+    }
+
+    @Override
+    public int countByRevieweeId(Long revieweeId) {
+        return reviewJpaRepository.countByRevieweeId(revieweeId);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/ReviewJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/ReviewJpaRepository.java
@@ -1,0 +1,20 @@
+package com.prothsync.prothsync.repository.jpa;
+
+import com.prothsync.prothsync.entity.review.Review;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ReviewJpaRepository extends JpaRepository<Review, Long> {
+
+    boolean existsByCaseRequestId(Long caseRequestId);
+
+    Page<Review> findAllByRevieweeIdOrderByCreatedAtDesc(Long revieweeId, Pageable pageable);
+
+    @Query("SELECT AVG(r.rating) FROM Review r WHERE r.revieweeId = :revieweeId")
+    Double findAverageRatingByRevieweeId(@Param("revieweeId") Long revieweeId);
+
+    int countByRevieweeId(Long revieweeId);
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/ReviewRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/ReviewRepository.java
@@ -1,0 +1,23 @@
+package com.prothsync.prothsync.repository.repository;
+
+import com.prothsync.prothsync.entity.review.Review;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ReviewRepository {
+
+    Review save(Review review);
+
+    Optional<Review> findById(Long reviewId);
+
+    void delete(Review review);
+
+    boolean existsByCaseRequestId(Long caseRequestId);
+
+    Page<Review> findAllByRevieweeId(Long revieweeId, Pageable pageable);
+
+    Double findAverageRatingByRevieweeId(Long revieweeId);
+
+    int countByRevieweeId(Long revieweeId);
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/ReviewService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/ReviewService.java
@@ -1,0 +1,211 @@
+package com.prothsync.prothsync.service;
+
+import com.prothsync.prothsync.dto.ReviewCreateRequestDTO;
+import com.prothsync.prothsync.dto.ReviewResponseDTO;
+import com.prothsync.prothsync.entity.caserequest.CaseRequest;
+import com.prothsync.prothsync.entity.caserequest.CaseProposal;
+import com.prothsync.prothsync.entity.caserequest.ProposalStatus;
+import com.prothsync.prothsync.entity.notification.NotificationType;
+import com.prothsync.prothsync.entity.notification.ReferenceType;
+import com.prothsync.prothsync.entity.review.Review;
+import com.prothsync.prothsync.entity.user.User;
+import com.prothsync.prothsync.exception.BusinessException;
+import com.prothsync.prothsync.exception.ReviewErrorCode;
+import com.prothsync.prothsync.exception.CaseErrorCode;
+import com.prothsync.prothsync.exception.UserErrorCode;
+import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.repository.repository.CaseProposalRepository;
+import com.prothsync.prothsync.repository.repository.CaseRequestRepository;
+import com.prothsync.prothsync.repository.repository.ReviewRepository;
+import com.prothsync.prothsync.repository.repository.UserRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+    private final CaseRequestRepository caseRequestRepository;
+    private final CaseProposalRepository caseProposalRepository;
+    private final UserRepository userRepository;
+    private final NotificationService notificationService;
+
+    /**
+     * 리뷰 작성
+     * 조건: 의뢰가 COMPLETED 상태 + 본인이 의뢰자 + 아직 리뷰 없음
+     * 대상: 해당 의뢰에서 ACCEPTED된 제안의 proposer
+     */
+    @Transactional
+    public ReviewResponseDTO createReview(
+        Long caseRequestId, Long reviewerId, ReviewCreateRequestDTO request) {
+
+        CaseRequest caseRequest = findCaseRequestOrThrow(caseRequestId);
+
+        // 검증: 완료된 의뢰인지
+        validateCaseCompleted(caseRequest);
+        // 검증: 의뢰자 본인인지
+        validateIsClient(caseRequest, reviewerId);
+        // 검증: 중복 리뷰 방지
+        validateNoExistingReview(caseRequestId);
+
+        // 수락된 제안의 proposer(기공사) 찾기
+        CaseProposal acceptedProposal = findAcceptedProposal(caseRequestId);
+        Long revieweeId = acceptedProposal.getProposerId();
+
+        Review review = Review.create(
+            caseRequestId, reviewerId, revieweeId,
+            request.rating(), request.content()
+        );
+
+        Review saved = reviewRepository.save(review);
+
+        // 리뷰 대상자의 평균 평점 갱신
+        updateUserRatingStats(revieweeId);
+
+        // 알림 발송
+        notificationService.send(
+            NotificationType.REVIEW_RECEIVED, reviewerId, revieweeId,
+            saved.getReviewId(), ReferenceType.REVIEW);
+
+        return ReviewResponseDTO.from(saved);
+    }
+
+    /**
+     * 특정 사용자가 받은 리뷰 목록 조회 (프로필에서 사용)
+     */
+    @Transactional(readOnly = true)
+    public PageResponse<ReviewResponseDTO> getReviewsByReviewee(
+        Long revieweeId, Pageable pageable) {
+
+        validateUserExists(revieweeId);
+
+        Page<Review> page = reviewRepository.findAllByRevieweeId(revieweeId, pageable);
+
+        List<ReviewResponseDTO> reviews = page.getContent().stream()
+            .map(ReviewResponseDTO::from)
+            .toList();
+
+        return PageResponse.of(reviews, page);
+    }
+
+    /**
+     * 리뷰 단건 조회
+     */
+    @Transactional(readOnly = true)
+    public ReviewResponseDTO getReview(Long reviewId) {
+        Review review = findReviewOrThrow(reviewId);
+        return ReviewResponseDTO.from(review);
+    }
+
+    /**
+     * 리뷰 수정 (작성자만 가능)
+     */
+    @Transactional
+    public ReviewResponseDTO updateReview(
+        Long reviewId, Long userId, ReviewCreateRequestDTO request) {
+
+        Review review = findReviewOrThrow(reviewId);
+        validateReviewOwner(review, userId);
+
+        if (request.rating() != null) {
+            review.updateRating(request.rating());
+        }
+        if (request.content() != null) {
+            review.updateContent(request.content());
+        }
+
+        Review updated = reviewRepository.save(review);
+
+        // 평점 변경 시 대상자의 평균 평점 갱신
+        updateUserRatingStats(review.getRevieweeId());
+
+        return ReviewResponseDTO.from(updated);
+    }
+
+    /**
+     * 리뷰 삭제 (작성자만 가능)
+     */
+    @Transactional
+    public void deleteReview(Long reviewId, Long userId) {
+        Review review = findReviewOrThrow(reviewId);
+        validateReviewOwner(review, userId);
+
+        Long revieweeId = review.getRevieweeId();
+
+        reviewRepository.delete(review);
+
+        // 삭제 후 대상자의 평균 평점 갱신
+        updateUserRatingStats(revieweeId);
+    }
+
+
+    // === private 메서드 ===
+
+    private void updateUserRatingStats(Long revieweeId) {
+        User reviewee = userRepository.findById(revieweeId)
+            .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        Double avgRating = reviewRepository.findAverageRatingByRevieweeId(revieweeId);
+        int reviewCount = reviewRepository.countByRevieweeId(revieweeId);
+
+        reviewee.updateRatingStats(
+            avgRating != null ? avgRating : 0.0,
+            reviewCount
+        );
+        userRepository.save(reviewee);
+    }
+
+    private CaseRequest findCaseRequestOrThrow(Long caseRequestId) {
+        return caseRequestRepository.findById(caseRequestId)
+            .orElseThrow(() -> new BusinessException(CaseErrorCode.CASE_NOT_FOUND));
+    }
+
+    private Review findReviewOrThrow(Long reviewId) {
+        return reviewRepository.findById(reviewId)
+            .orElseThrow(() -> new BusinessException(ReviewErrorCode.REVIEW_NOT_FOUND));
+    }
+
+    private CaseProposal findAcceptedProposal(Long caseRequestId) {
+        List<CaseProposal> accepted = caseProposalRepository
+            .findAllByCaseRequestIdAndStatus(caseRequestId, ProposalStatus.ACCEPTED);
+
+        if (accepted.isEmpty()) {
+            throw new BusinessException(CaseErrorCode.CASE_NO_ACCEPTED_PROPOSAL);
+        }
+        return accepted.get(0);
+    }
+
+    private void validateCaseCompleted(CaseRequest caseRequest) {
+        if (caseRequest.getStatus() != com.prothsync.prothsync.entity.caserequest.CaseStatus.COMPLETED) {
+            throw new BusinessException(ReviewErrorCode.REVIEW_CASE_NOT_COMPLETED);
+        }
+    }
+
+    private void validateIsClient(CaseRequest caseRequest, Long userId) {
+        if (!caseRequest.isOwner(userId)) {
+            throw new BusinessException(ReviewErrorCode.REVIEW_NOT_CLIENT);
+        }
+    }
+
+    private void validateNoExistingReview(Long caseRequestId) {
+        if (reviewRepository.existsByCaseRequestId(caseRequestId)) {
+            throw new BusinessException(ReviewErrorCode.REVIEW_ALREADY_EXISTS);
+        }
+    }
+
+    private void validateReviewOwner(Review review, Long userId) {
+        if (!review.isWrittenBy(userId)) {
+            throw new BusinessException(ReviewErrorCode.REVIEW_ACCESS_DENIED);
+        }
+    }
+
+    private void validateUserExists(Long userId) {
+        userRepository.findById(userId)
+            .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
# 변경사항
- 의뢰자가 의뢰를 완료 처리한 후 작업을 수행한 기공사에게 리뷰를 남기는 구조 입니다.

## 구현사항
- 의뢰 COMPLETED 상태에서만 리뷰 작성 가능
- 의뢰자만 리뷰 작성 가능
- 의뢰당 1개 리뷰만 허용
- 리뷰 대상은 자동 결정 - 수락된 제안의 proposer
- 평균 평점은 User 엔티티에 비정규화 - 리뷰 CUD 시마다 갱신
- 알림 자동 발송 - 리뷰 작성 시 기공사에게 REVIEW_RECEIVED 알림