### PR TITLE
feat: 북마크 기능 구현

### DIFF
--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/BookmarkController.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/BookmarkController.java
@@ -1,0 +1,55 @@
+package com.prothsync.prothsync.controller;
+
+import com.prothsync.prothsync.controller.docs.BookmarkControllerDocs;
+import com.prothsync.prothsync.dto.BookmarkResponseDTO;
+import com.prothsync.prothsync.dto.PostResponseDTO;
+import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.security.CustomUserDetails;
+import com.prothsync.prothsync.service.BookmarkService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class BookmarkController implements BookmarkControllerDocs {
+
+    private final BookmarkService bookmarkService;
+
+    @PostMapping("/posts/{postId}/bookmarks")
+    public ResponseEntity<BookmarkResponseDTO> toggleBookmark(
+        @PathVariable Long postId,
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        BookmarkResponseDTO response = bookmarkService.toggleBookmark(
+            postId, userDetails.getUserId());
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/bookmarks/me")
+    public ResponseEntity<PageResponse<PostResponseDTO>> getMyBookmarks(
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        Pageable pageable
+    ) {
+        PageResponse<PostResponseDTO> response = bookmarkService.getMyBookmarks(
+            userDetails.getUserId(), pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/posts/{postId}/bookmarks")
+    public ResponseEntity<Boolean> isBookmarked(
+        @PathVariable Long postId,
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        boolean bookmarked = bookmarkService.isBookmarked(
+            postId, userDetails.getUserId());
+        return ResponseEntity.ok(bookmarked);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/BookmarkControllerDocs.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/BookmarkControllerDocs.java
@@ -1,0 +1,63 @@
+package com.prothsync.prothsync.controller.docs;
+
+import com.prothsync.prothsync.dto.BookmarkResponseDTO;
+import com.prothsync.prothsync.dto.PostResponseDTO;
+import com.prothsync.prothsync.exception.ErrorResponse;
+import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "북마크", description = "게시글 북마크(스크랩) API")
+@SecurityRequirement(name = "bearerAuth")
+public interface BookmarkControllerDocs {
+
+    @Operation(summary = "북마크 토글", description = "게시글을 북마크하거나 해제합니다.")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "북마크 토글 성공",
+            content = @Content(schema = @Schema(implementation = BookmarkResponseDTO.class))
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description = "인증 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "게시글을 찾을 수 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<BookmarkResponseDTO> toggleBookmark(
+        @Parameter(description = "게시글 ID") Long postId,
+        CustomUserDetails userDetails
+    );
+
+    @Operation(summary = "내 북마크 목록 조회", description = "현재 사용자가 북마크한 게시글 목록을 조회합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    ResponseEntity<PageResponse<PostResponseDTO>> getMyBookmarks(
+        CustomUserDetails userDetails,
+        Pageable pageable
+    );
+
+    @Operation(summary = "북마크 여부 확인", description = "현재 사용자가 해당 게시글을 북마크했는지 확인합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    ResponseEntity<Boolean> isBookmarked(
+        @Parameter(description = "게시글 ID") Long postId,
+        CustomUserDetails userDetails
+    );
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/dto/BookmarkResponseDTO.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/dto/BookmarkResponseDTO.java
@@ -1,0 +1,18 @@
+package com.prothsync.prothsync.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "북마크 토글 응답 DTO")
+public record BookmarkResponseDTO(
+
+    @Schema(description = "게시글 ID")
+    Long postId,
+
+    @Schema(description = "북마크 여부")
+    boolean bookmarked
+) {
+
+    public static BookmarkResponseDTO of(Long postId, boolean bookmarked) {
+        return new BookmarkResponseDTO(postId, bookmarked);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/dto/PostResponseDTO.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/dto/PostResponseDTO.java
@@ -18,6 +18,7 @@ public record PostResponseDTO(
     int commentCount,
     int viewCount,
     boolean isLiked,
+    boolean isBookmarked,
     LocalDateTime createdAt,
     LocalDateTime updatedAt
 ) {
@@ -26,7 +27,8 @@ public record PostResponseDTO(
         Post post,
         List<PostImageResponseDTO> images,
         List<HashtagResponseDTO> hashtags,
-        boolean isLiked
+        boolean isLiked,
+        boolean isBookmarked
     ) {
         return new PostResponseDTO(
             post.getPostId(),
@@ -40,6 +42,7 @@ public record PostResponseDTO(
             post.getCommentCount(),
             post.getViewCount(),
             isLiked,
+            isBookmarked,
             post.getCreatedAt(),
             post.getUpdatedAt()
         );

--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/post/Bookmark.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/post/Bookmark.java
@@ -1,0 +1,68 @@
+package com.prothsync.prothsync.entity.post;
+
+import com.prothsync.prothsync.common.BaseEntity;
+import com.prothsync.prothsync.exception.BusinessException;
+import com.prothsync.prothsync.exception.PostErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+    name = "bookmarks",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_bookmarks_user_post",
+            columnNames = {"user_id", "post_id"}
+        )
+    }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Bookmark extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long bookmarkId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "post_id", nullable = false)
+    private Long postId;
+
+    private Bookmark(Long userId, Long postId) {
+        this.userId = userId;
+        this.postId = postId;
+    }
+
+    public static Bookmark create(Long userId, Long postId) {
+        validateUserId(userId);
+        validatePostId(postId);
+
+        return new Bookmark(userId, postId);
+    }
+
+    private static void validateUserId(Long userId) {
+        if (userId == null) {
+            throw new BusinessException(PostErrorCode.POST_USER_ID_NULL);
+        }
+    }
+
+    private static void validatePostId(Long postId) {
+        if (postId == null) {
+            throw new BusinessException(PostErrorCode.POST_ID_NULL);
+        }
+    }
+
+    public boolean isOwnedBy(Long userId) {
+        return this.userId.equals(userId);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/exception/PostErrorCode.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/exception/PostErrorCode.java
@@ -47,6 +47,8 @@ public enum PostErrorCode implements ErrorCode {
     HASHTAG_INVALID_PATTERN(HttpStatus.BAD_REQUEST, "해시태그는 한글, 영문, 숫자, 밑줄(_)만 사용 가능합니다."),
     HASHTAG_TOO_LONG(HttpStatus.BAD_REQUEST, "해시태그가 너무 깁니다.(최대 50자)"),
     HASHTAG_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "게시글당 해시태그는 최대 30개까지 등록 가능합니다."),
+
+    BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "북마크 정보를 찾을 수 없습니다."),
     ;
 
     private final HttpStatus status;

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/BookmarkRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/BookmarkRepositoryImpl.java
@@ -1,0 +1,47 @@
+package com.prothsync.prothsync.repository.impl;
+
+import com.prothsync.prothsync.entity.post.Bookmark;
+import com.prothsync.prothsync.repository.jpa.BookmarkJpaRepository;
+import com.prothsync.prothsync.repository.repository.BookmarkRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class BookmarkRepositoryImpl implements BookmarkRepository {
+
+    private final BookmarkJpaRepository bookmarkJpaRepository;
+
+    @Override
+    public Bookmark save(Bookmark bookmark) {
+        return bookmarkJpaRepository.save(bookmark);
+    }
+
+    @Override
+    public Optional<Bookmark> findByUserIdAndPostId(Long userId, Long postId) {
+        return bookmarkJpaRepository.findByUserIdAndPostId(userId, postId);
+    }
+
+    @Override
+    public void delete(Bookmark bookmark) {
+        bookmarkJpaRepository.delete(bookmark);
+    }
+
+    @Override
+    public void deleteAllByPostId(Long postId) {
+        bookmarkJpaRepository.deleteAllByPostId(postId);
+    }
+
+    @Override
+    public boolean existsByUserIdAndPostId(Long userId, Long postId) {
+        return bookmarkJpaRepository.existsByUserIdAndPostId(userId, postId);
+    }
+
+    @Override
+    public Page<Bookmark> findAllByUserId(Long userId, Pageable pageable) {
+        return bookmarkJpaRepository.findAllByUserIdOrderByCreatedAtDesc(userId, pageable);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/BookmarkJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/BookmarkJpaRepository.java
@@ -1,0 +1,18 @@
+package com.prothsync.prothsync.repository.jpa;
+
+import com.prothsync.prothsync.entity.post.Bookmark;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookmarkJpaRepository extends JpaRepository<Bookmark, Long> {
+
+    Optional<Bookmark> findByUserIdAndPostId(Long userId, Long postId);
+
+    boolean existsByUserIdAndPostId(Long userId, Long postId);
+
+    Page<Bookmark> findAllByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
+    void deleteAllByPostId(Long postId);
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/BookmarkRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/BookmarkRepository.java
@@ -1,0 +1,21 @@
+package com.prothsync.prothsync.repository.repository;
+
+import com.prothsync.prothsync.entity.post.Bookmark;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface BookmarkRepository {
+
+    Bookmark save(Bookmark bookmark);
+
+    Optional<Bookmark> findByUserIdAndPostId(Long userId, Long postId);
+
+    void delete(Bookmark bookmark);
+
+    void deleteAllByPostId(Long postId);
+
+    boolean existsByUserIdAndPostId(Long userId, Long postId);
+
+    Page<Bookmark> findAllByUserId(Long userId, Pageable pageable);
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/BookmarkService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/BookmarkService.java
@@ -1,0 +1,86 @@
+package com.prothsync.prothsync.service;
+
+import com.prothsync.prothsync.dto.BookmarkResponseDTO;
+import com.prothsync.prothsync.dto.HashtagResponseDTO;
+import com.prothsync.prothsync.dto.PostImageResponseDTO;
+import com.prothsync.prothsync.dto.PostResponseDTO;
+import com.prothsync.prothsync.entity.post.Bookmark;
+import com.prothsync.prothsync.entity.post.Post;
+import com.prothsync.prothsync.exception.BusinessException;
+import com.prothsync.prothsync.exception.PostErrorCode;
+import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.repository.repository.BookmarkRepository;
+import com.prothsync.prothsync.repository.repository.PostLikeRepository;
+import com.prothsync.prothsync.repository.repository.PostRepository;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BookmarkService {
+
+    private final BookmarkRepository bookmarkRepository;
+    private final PostRepository postRepository;
+    private final PostLikeRepository postLikeRepository;
+    private final PostImageService postImageService;
+    private final HashtagService hashtagService;
+
+    @Transactional
+    public BookmarkResponseDTO toggleBookmark(Long postId, Long userId) {
+        findPostOrThrow(postId);
+
+        Optional<Bookmark> existing = bookmarkRepository.findByUserIdAndPostId(userId, postId);
+
+        if (existing.isPresent()) {
+            bookmarkRepository.delete(existing.get());
+            return BookmarkResponseDTO.of(postId, false);
+        } else {
+            Bookmark bookmark = Bookmark.create(userId, postId);
+            bookmarkRepository.save(bookmark);
+            return BookmarkResponseDTO.of(postId, true);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponse<PostResponseDTO> getMyBookmarks(Long userId, Pageable pageable) {
+        Page<Bookmark> bookmarkPage = bookmarkRepository.findAllByUserId(userId, pageable);
+
+        List<PostResponseDTO> posts = bookmarkPage.getContent().stream()
+            .map(bookmark -> {
+                Post post = postRepository.findById(bookmark.getPostId())
+                    .orElse(null);
+                if (post == null) {
+                    return null;
+                }
+                return buildPostResponseDTO(post, userId);
+            })
+            .filter(dto -> dto != null)
+            .toList();
+
+        return PageResponse.of(posts, bookmarkPage);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isBookmarked(Long postId, Long userId) {
+        return bookmarkRepository.existsByUserIdAndPostId(userId, postId);
+    }
+
+    private Post findPostOrThrow(Long postId) {
+        return postRepository.findById(postId)
+            .orElseThrow(() -> new BusinessException(PostErrorCode.POST_NOT_FOUND));
+    }
+
+    private PostResponseDTO buildPostResponseDTO(Post post, Long currentUserId) {
+        List<PostImageResponseDTO> imageDtos = postImageService.getImagesByPostId(post.getPostId());
+        List<HashtagResponseDTO> hashtagDtos = hashtagService.getHashtagsByPostId(post.getPostId());
+        boolean isLiked = postLikeRepository.existsByUserIdAndPostId(currentUserId, post.getPostId());
+        boolean isBookmarked = bookmarkRepository.existsByUserIdAndPostId(currentUserId, post.getPostId());
+
+        return PostResponseDTO.of(post, imageDtos, hashtagDtos, isLiked, isBookmarked);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/FeedService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/FeedService.java
@@ -5,6 +5,7 @@ import com.prothsync.prothsync.dto.PostImageResponseDTO;
 import com.prothsync.prothsync.dto.PostResponseDTO;
 import com.prothsync.prothsync.entity.post.Post;
 import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.repository.repository.BookmarkRepository;
 import com.prothsync.prothsync.repository.repository.FollowRepository;
 import com.prothsync.prothsync.repository.repository.PostLikeRepository;
 import com.prothsync.prothsync.repository.repository.PostRepository;
@@ -24,6 +25,7 @@ public class FeedService {
     private final PostImageService postImageService;
     private final HashtagService hashtagService;
     private final PostLikeRepository postLikeRepository;
+    private final BookmarkRepository bookmarkRepository;
 
     @Transactional(readOnly = true)
     public PageResponse<PostResponseDTO> getFollowingFeed(Long userId, Pageable pageable) {
@@ -47,7 +49,9 @@ public class FeedService {
         List<HashtagResponseDTO> hashtagDtos = hashtagService.getHashtagsByPostId(post.getPostId());
         boolean isLiked = currentUserId != null
             && postLikeRepository.existsByUserIdAndPostId(currentUserId, post.getPostId());
+        boolean isBookmarked = currentUserId != null                                    // ★ 추가
+            && bookmarkRepository.existsByUserIdAndPostId(currentUserId, post.getPostId());
 
-        return PostResponseDTO.of(post, imageDtos, hashtagDtos, isLiked);
+        return PostResponseDTO.of(post, imageDtos, hashtagDtos, isLiked, isBookmarked); // ★ 파라미터 추가
     }
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/PostService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/PostService.java
@@ -14,6 +14,7 @@ import com.prothsync.prothsync.exception.BusinessException;
 import com.prothsync.prothsync.exception.PostErrorCode;
 import com.prothsync.prothsync.exception.UserErrorCode;
 import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.repository.repository.BookmarkRepository;
 import com.prothsync.prothsync.repository.repository.PostLikeRepository;
 import com.prothsync.prothsync.repository.repository.PostRepository;
 import com.prothsync.prothsync.repository.repository.UserRepository;
@@ -34,6 +35,7 @@ public class PostService {
     private final HashtagService hashtagService;
     private final PostImageService postImageService;
     private final CommentService commentService;
+    private final BookmarkRepository bookmarkRepository;
 
     @Transactional
     public PostResponseDTO createPost(Long userId, PostCreateRequestDTO request) {
@@ -123,6 +125,7 @@ public class PostService {
         validatePostOwner(post, userId);
 
         postLikeRepository.deleteAllByPostId(postId);
+        bookmarkRepository.deleteAllByPostId(postId);
         commentService.deleteAllByPostId(postId);
         hashtagService.removeAllHashtagsFromPost(postId);
         postImageService.deleteAllByPostId(postId);
@@ -157,8 +160,10 @@ public class PostService {
         List<HashtagResponseDTO> hashtagDtos = hashtagService.getHashtagsByPostId(post.getPostId());
         boolean isLiked = currentUserId != null
             && postLikeRepository.existsByUserIdAndPostId(currentUserId, post.getPostId());
+        boolean isBookmarked = currentUserId != null
+            && bookmarkRepository.existsByUserIdAndPostId(currentUserId, post.getPostId());
 
-        return PostResponseDTO.of(post, imageDtos, hashtagDtos, isLiked);
+        return PostResponseDTO.of(post, imageDtos, hashtagDtos, isLiked, isBookmarked);
     }
 
     private PostResponseDTO toPostResponseDTO(
@@ -171,7 +176,7 @@ public class PostService {
             .map(HashtagResponseDTO::from)
             .toList();
 
-        return PostResponseDTO.of(post, imageDtos, hashtagDtos, isLiked);
+        return PostResponseDTO.of(post, imageDtos, hashtagDtos, isLiked, false);
     }
 
     private PageResponse<PostSummaryResponseDTO> toSummaryPageResponse(Page<Post> postPage) {


### PR DESCRIPTION
# 변경사항
- 북마크 기능을 구현하였습니다.
- 좋아요와 구조적으로 동일하되, 북마크 카운트는 게시글에 노출하지 않습니다.
- 인스타그램 저장과 동일한 개념 - 저장 수는 비공개

## 설계 포인트
- PostLike와 동일한 구조이기 때문에 Entity 패키지도 Post 하위에 구현했습니다.
- UniqueConstraint로 사용자당 게시글 1번만 북마크 가능하게 하였습니다.
- 기존 PostErrorCode를 재사용 하였습니다.

### 좋아요 와 북마크의 차이점 정리
post에 카운트 -> 좋아요는 하지만 북마크는 비공개 정보이기 때문에 카운트를 하지 않음
알림 발송 -> 좋아요는 게시글 작성자에게 발송되지만, 북마크는 개인 행동이기 때문에 알림 발송 X
다른 사용자에게 노출 -> 좋아요 수 는 공개 되지만 북마크는 공개되지 않습니다.
