### PR TITLE
feat: 사용자 차단 기능 구현

### DIFF
--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/BlockController.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/BlockController.java
@@ -1,0 +1,63 @@
+package com.prothsync.prothsync.controller;
+
+import com.prothsync.prothsync.controller.docs.BlockControllerDocs;
+import com.prothsync.prothsync.dto.BlockResponseDTO;
+import com.prothsync.prothsync.dto.BlockedUserResponseDTO;
+import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.security.CustomUserDetails;
+import com.prothsync.prothsync.service.BlockService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/blocks")
+public class BlockController implements BlockControllerDocs {
+
+    private final BlockService blockService;
+
+    @PostMapping("/{userId}")
+    public ResponseEntity<BlockResponseDTO> block(
+        @PathVariable Long userId,
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        BlockResponseDTO response = blockService.block(userDetails.getUserId(), userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<BlockResponseDTO> unblock(
+        @PathVariable Long userId,
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        BlockResponseDTO response = blockService.unblock(userDetails.getUserId(), userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<PageResponse<BlockedUserResponseDTO>> getBlockedUsers(
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        Pageable pageable
+    ) {
+        PageResponse<BlockedUserResponseDTO> response = blockService.getBlockedUsers(
+            userDetails.getUserId(), pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{userId}/status")
+    public ResponseEntity<Boolean> isBlocked(
+        @PathVariable Long userId,
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        boolean blocked = blockService.isBlocked(userDetails.getUserId(), userId);
+        return ResponseEntity.ok(blocked);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/SearchController.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/SearchController.java
@@ -5,10 +5,12 @@ import com.prothsync.prothsync.dto.HashtagResponseDTO;
 import com.prothsync.prothsync.dto.PostSummaryResponseDTO;
 import com.prothsync.prothsync.dto.UserSearchResponseDTO;
 import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.security.CustomUserDetails;
 import com.prothsync.prothsync.service.SearchService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -35,9 +37,12 @@ public class SearchController implements SearchControllerDocs {
     @GetMapping("/posts")
     public ResponseEntity<PageResponse<PostSummaryResponseDTO>> searchPostsByHashtag(
         @RequestParam String hashtag,
+        @AuthenticationPrincipal CustomUserDetails userDetails,
         Pageable pageable
     ) {
-        PageResponse<PostSummaryResponseDTO> response = searchService.searchPostsByHashtag(hashtag, pageable);
+        Long currentUserId = userDetails != null ? userDetails.getUserId() : null;
+        PageResponse<PostSummaryResponseDTO> response = searchService.searchPostsByHashtag(
+            hashtag, currentUserId, pageable);
         return ResponseEntity.ok(response);
     }
 
@@ -45,9 +50,12 @@ public class SearchController implements SearchControllerDocs {
     @GetMapping("/users")
     public ResponseEntity<PageResponse<UserSearchResponseDTO>> searchUsers(
         @RequestParam String keyword,
+        @AuthenticationPrincipal CustomUserDetails userDetails,
         Pageable pageable
     ) {
-        PageResponse<UserSearchResponseDTO> response = searchService.searchUsers(keyword, pageable);
+        Long currentUserId = userDetails != null ? userDetails.getUserId() : null;
+        PageResponse<UserSearchResponseDTO> response = searchService.searchUsers(
+            keyword, currentUserId, pageable);
         return ResponseEntity.ok(response);
     }
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/BlockControllerDocs.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/BlockControllerDocs.java
@@ -1,0 +1,101 @@
+package com.prothsync.prothsync.controller.docs;
+
+import com.prothsync.prothsync.dto.BlockResponseDTO;
+import com.prothsync.prothsync.dto.BlockedUserResponseDTO;
+import com.prothsync.prothsync.exception.ErrorResponse;
+import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "차단", description = "사용자 차단 API")
+@SecurityRequirement(name = "bearerAuth")
+public interface BlockControllerDocs {
+
+    @Operation(summary = "사용자 차단", description = "대상 사용자를 차단합니다. 차단 시 양방향 팔로우 관계가 자동으로 해제됩니다.")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "차단 성공",
+            content = @Content(schema = @Schema(implementation = BlockResponseDTO.class))
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "자기 자신을 차단할 수 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description = "인증 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "사용자를 찾을 수 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description = "이미 차단한 사용자",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<BlockResponseDTO> block(
+        @Parameter(description = "차단할 사용자 ID") Long userId,
+        CustomUserDetails userDetails
+    );
+
+    @Operation(summary = "차단 해제", description = "대상 사용자의 차단을 해제합니다.")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "차단 해제 성공",
+            content = @Content(schema = @Schema(implementation = BlockResponseDTO.class))
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description = "인증 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "차단 정보를 찾을 수 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<BlockResponseDTO> unblock(
+        @Parameter(description = "차단 해제할 사용자 ID") Long userId,
+        CustomUserDetails userDetails
+    );
+
+    @Operation(summary = "차단 목록 조회", description = "내가 차단한 사용자 목록을 페이징하여 조회합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공"),
+        @ApiResponse(
+            responseCode = "401",
+            description = "인증 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<PageResponse<BlockedUserResponseDTO>> getBlockedUsers(
+        CustomUserDetails userDetails,
+        Pageable pageable
+    );
+
+    @Operation(summary = "차단 여부 확인", description = "대상 사용자를 차단하고 있는지 확인합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    ResponseEntity<Boolean> isBlocked(
+        @Parameter(description = "대상 사용자 ID") Long userId,
+        CustomUserDetails userDetails
+    );
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/SearchControllerDocs.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/SearchControllerDocs.java
@@ -4,10 +4,12 @@ import com.prothsync.prothsync.dto.HashtagResponseDTO;
 import com.prothsync.prothsync.dto.PostSummaryResponseDTO;
 import com.prothsync.prothsync.dto.UserSearchResponseDTO;
 import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -30,8 +32,10 @@ public interface SearchControllerDocs {
 
     @Operation(
         summary = "해시태그로 게시물 검색",
-        description = "특정 해시태그가 달린 공개 게시물을 최신순으로 조회합니다. '#' 접두사는 자동으로 제거됩니다."
+        description = "특정 해시태그가 달린 공개 게시물을 최신순으로 조회합니다. "
+            + "로그인 시 차단한 사용자의 게시물은 제외됩니다. '#' 접두사는 자동으로 제거됩니다."
     )
+    @SecurityRequirement(name = "bearerAuth")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "검색 성공"),
         @ApiResponse(responseCode = "400", description = "검색 키워드가 비어있거나 너무 깁니다"),
@@ -39,19 +43,23 @@ public interface SearchControllerDocs {
     })
     ResponseEntity<PageResponse<PostSummaryResponseDTO>> searchPostsByHashtag(
         @Parameter(description = "해시태그 이름 (예: 임플란트, 크라운)", required = true) String hashtag,
+        CustomUserDetails userDetails,
         Pageable pageable
     );
 
     @Operation(
         summary = "사용자 닉네임 검색",
-        description = "닉네임에 키워드가 포함된 사용자를 조회합니다. 대소문자를 구분하지 않습니다."
+        description = "닉네임에 키워드가 포함된 사용자를 조회합니다. "
+            + "로그인 시 차단한 사용자는 결과에서 제외됩니다. 대소문자를 구분하지 않습니다."
     )
+    @SecurityRequirement(name = "bearerAuth")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "검색 성공"),
         @ApiResponse(responseCode = "400", description = "검색 키워드가 비어있거나 너무 깁니다")
     })
     ResponseEntity<PageResponse<UserSearchResponseDTO>> searchUsers(
         @Parameter(description = "검색 키워드 (닉네임)", required = true) String keyword,
+        CustomUserDetails userDetails,
         Pageable pageable
     );
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/dto/BlockResponseDTO.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/dto/BlockResponseDTO.java
@@ -1,0 +1,10 @@
+package com.prothsync.prothsync.dto;
+
+public record BlockResponseDTO(
+    Long targetUserId,
+    boolean blocked
+) {
+    public static BlockResponseDTO of(Long targetUserId, boolean blocked) {
+        return new BlockResponseDTO(targetUserId, blocked);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/dto/BlockedUserResponseDTO.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/dto/BlockedUserResponseDTO.java
@@ -1,0 +1,23 @@
+package com.prothsync.prothsync.dto;
+
+import com.prothsync.prothsync.entity.user.User;
+import com.prothsync.prothsync.entity.user.UserType;
+import java.time.LocalDateTime;
+
+public record BlockedUserResponseDTO(
+    Long userId,
+    String nickName,
+    UserType userType,
+    String profileImageUrl,
+    LocalDateTime blockedAt
+) {
+    public static BlockedUserResponseDTO of(User user, LocalDateTime blockedAt) {
+        return new BlockedUserResponseDTO(
+            user.getUserId(),
+            user.getNickName(),
+            user.getUserType(),
+            user.getProfileImageUrl(),
+            blockedAt
+        );
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/block/Block.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/block/Block.java
@@ -1,0 +1,71 @@
+package com.prothsync.prothsync.entity.block;
+
+import com.prothsync.prothsync.common.BaseEntity;
+import com.prothsync.prothsync.exception.BlockErrorCode;
+import com.prothsync.prothsync.exception.BusinessException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+    name = "blocks",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_blocks_blocker_blocked",
+            columnNames = {"blocker_id", "blocked_id"}
+        )
+    }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Block extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long blockId;
+
+    @Column(name = "blocker_id", nullable = false)
+    private Long blockerId;
+
+    @Column(name = "blocked_id", nullable = false)
+    private Long blockedId;
+
+    private Block(Long blockerId, Long blockedId) {
+        this.blockerId = blockerId;
+        this.blockedId = blockedId;
+    }
+
+    public static Block create(Long blockerId, Long blockedId) {
+        validateBlockerId(blockerId);
+        validateBlockedId(blockedId);
+        validateNotSelf(blockerId, blockedId);
+
+        return new Block(blockerId, blockedId);
+    }
+
+    private static void validateBlockerId(Long blockerId) {
+        if (blockerId == null) {
+            throw new BusinessException(BlockErrorCode.BLOCKER_ID_NULL);
+        }
+    }
+
+    private static void validateBlockedId(Long blockedId) {
+        if (blockedId == null) {
+            throw new BusinessException(BlockErrorCode.BLOCKED_ID_NULL);
+        }
+    }
+
+    private static void validateNotSelf(Long blockerId, Long blockedId) {
+        if (blockerId.equals(blockedId)) {
+            throw new BusinessException(BlockErrorCode.CANNOT_BLOCK_SELF);
+        }
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/exception/BlockErrorCode.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/exception/BlockErrorCode.java
@@ -1,0 +1,21 @@
+package com.prothsync.prothsync.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum BlockErrorCode implements ErrorCode {
+
+    BLOCKER_ID_NULL(HttpStatus.BAD_REQUEST, "차단자 ID가 NULL 입니다."),
+    BLOCKED_ID_NULL(HttpStatus.BAD_REQUEST, "차단 대상 ID가 NULL 입니다."),
+    CANNOT_BLOCK_SELF(HttpStatus.BAD_REQUEST, "자기 자신을 차단할 수 없습니다."),
+    ALREADY_BLOCKED(HttpStatus.CONFLICT, "이미 차단한 사용자입니다."),
+    BLOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "차단 정보를 찾을 수 없습니다."),
+    BLOCKED_USER(HttpStatus.FORBIDDEN, "차단된 사용자입니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/BlockRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/BlockRepositoryImpl.java
@@ -1,0 +1,48 @@
+package com.prothsync.prothsync.repository.impl;
+
+import com.prothsync.prothsync.entity.block.Block;
+import com.prothsync.prothsync.repository.jpa.BlockJpaRepository;
+import com.prothsync.prothsync.repository.repository.BlockRepository;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class BlockRepositoryImpl implements BlockRepository {
+
+    private final BlockJpaRepository blockJpaRepository;
+
+    @Override
+    public Block save(Block block) {
+        return blockJpaRepository.save(block);
+    }
+
+    @Override
+    public boolean existsByBlockerIdAndBlockedId(Long blockerId, Long blockedId) {
+        return blockJpaRepository.existsByBlockerIdAndBlockedId(blockerId, blockedId);
+    }
+
+    @Override
+    public Optional<Block> findByBlockerIdAndBlockedId(Long blockerId, Long blockedId) {
+        return blockJpaRepository.findByBlockerIdAndBlockedId(blockerId, blockedId);
+    }
+
+    @Override
+    public Page<Block> findAllByBlockerId(Long blockerId, Pageable pageable) {
+        return blockJpaRepository.findAllByBlockerId(blockerId, pageable);
+    }
+
+    @Override
+    public List<Long> findBlockedIdsByBlockerId(Long blockerId) {
+        return blockJpaRepository.findBlockedIdsByBlockerId(blockerId);
+    }
+
+    @Override
+    public void delete(Block block) {
+        blockJpaRepository.delete(block);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/BlockJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/BlockJpaRepository.java
@@ -1,0 +1,22 @@
+package com.prothsync.prothsync.repository.jpa;
+
+import com.prothsync.prothsync.entity.block.Block;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface BlockJpaRepository extends JpaRepository<Block, Long> {
+
+    boolean existsByBlockerIdAndBlockedId(Long blockerId, Long blockedId);
+
+    Optional<Block> findByBlockerIdAndBlockedId(Long blockerId, Long blockedId);
+
+    Page<Block> findAllByBlockerId(Long blockerId, Pageable pageable);
+
+    @Query("SELECT b.blockedId FROM Block b WHERE b.blockerId = :blockerId")
+    List<Long> findBlockedIdsByBlockerId(@Param("blockerId") Long blockerId);
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/BlockRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/BlockRepository.java
@@ -1,0 +1,22 @@
+package com.prothsync.prothsync.repository.repository;
+
+import com.prothsync.prothsync.entity.block.Block;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface BlockRepository {
+
+    Block save(Block block);
+
+    boolean existsByBlockerIdAndBlockedId(Long blockerId, Long blockedId);
+
+    Optional<Block> findByBlockerIdAndBlockedId(Long blockerId, Long blockedId);
+
+    Page<Block> findAllByBlockerId(Long blockerId, Pageable pageable);
+
+    List<Long> findBlockedIdsByBlockerId(Long blockerId);
+
+    void delete(Block block);
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/BlockService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/BlockService.java
@@ -1,0 +1,113 @@
+package com.prothsync.prothsync.service;
+
+import com.prothsync.prothsync.dto.BlockResponseDTO;
+import com.prothsync.prothsync.dto.BlockedUserResponseDTO;
+import com.prothsync.prothsync.entity.block.Block;
+import com.prothsync.prothsync.entity.user.Follow;
+import com.prothsync.prothsync.entity.user.User;
+import com.prothsync.prothsync.exception.BlockErrorCode;
+import com.prothsync.prothsync.exception.BusinessException;
+import com.prothsync.prothsync.exception.UserErrorCode;
+import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.repository.repository.BlockRepository;
+import com.prothsync.prothsync.repository.repository.FollowRepository;
+import com.prothsync.prothsync.repository.repository.UserRepository;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BlockService {
+
+    private final BlockRepository blockRepository;
+    private final UserRepository userRepository;
+    private final FollowRepository followRepository;
+
+
+    @Transactional
+    public BlockResponseDTO block(Long blockerId, Long blockedId) {
+        findUserOrThrow(blockerId);
+        findUserOrThrow(blockedId);
+
+        if (blockRepository.existsByBlockerIdAndBlockedId(blockerId, blockedId)) {
+            throw new BusinessException(BlockErrorCode.ALREADY_BLOCKED);
+        }
+
+        removeFollowIfExists(blockerId, blockedId);
+        removeFollowIfExists(blockedId, blockerId);
+
+        Block block = Block.create(blockerId, blockedId);
+        blockRepository.save(block);
+
+        return BlockResponseDTO.of(blockedId, true);
+    }
+
+    @Transactional
+    public BlockResponseDTO unblock(Long blockerId, Long blockedId) {
+        Block block = blockRepository.findByBlockerIdAndBlockedId(blockerId, blockedId)
+            .orElseThrow(() -> new BusinessException(BlockErrorCode.BLOCK_NOT_FOUND));
+
+        blockRepository.delete(block);
+
+        return BlockResponseDTO.of(blockedId, false);
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponse<BlockedUserResponseDTO> getBlockedUsers(Long blockerId, Pageable pageable) {
+        findUserOrThrow(blockerId);
+
+        Page<Block> blockPage = blockRepository.findAllByBlockerId(blockerId, pageable);
+
+        List<BlockedUserResponseDTO> blockedUsers = blockPage.getContent().stream()
+            .map(block -> {
+                User blockedUser = findUserOrThrow(block.getBlockedId());
+                return BlockedUserResponseDTO.of(blockedUser, block.getCreatedAt());
+            })
+            .toList();
+
+        return PageResponse.of(blockedUsers, blockPage);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isBlocked(Long blockerId, Long blockedId) {
+        return blockRepository.existsByBlockerIdAndBlockedId(blockerId, blockedId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Long> getBlockedIds(Long blockerId) {
+        return blockRepository.findBlockedIdsByBlockerId(blockerId);
+    }
+
+    @Transactional(readOnly = true)
+    public void validateNotBlocked(Long userId, Long targetUserId) {
+        if (blockRepository.existsByBlockerIdAndBlockedId(userId, targetUserId)
+            || blockRepository.existsByBlockerIdAndBlockedId(targetUserId, userId)) {
+            throw new BusinessException(BlockErrorCode.BLOCKED_USER);
+        }
+    }
+
+    private void removeFollowIfExists(Long followerId, Long followingId) {
+        Optional<Follow> follow = followRepository.findByFollowerIdAndFollowingId(followerId, followingId);
+        if (follow.isPresent()) {
+            followRepository.delete(follow.get());
+
+            User follower = findUserOrThrow(followerId);
+            User following = findUserOrThrow(followingId);
+            follower.decrementFollowingCount();
+            following.decrementFollowerCount();
+            userRepository.save(follower);
+            userRepository.save(following);
+        }
+    }
+
+    private User findUserOrThrow(Long userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+    }
+
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/CommentService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/CommentService.java
@@ -26,10 +26,13 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final PostRepository postRepository;
     private final NotificationService notificationService;
+    private final BlockService blockService;
 
     @Transactional
     public CommentResponseDTO createComment(Long postId, Long userId, CommentCreateRequestDTO request) {
         Post post = findPostOrThrow(postId);
+
+        blockService.validateNotBlocked(userId, post.getUserId());
 
         Comment comment = Comment.createComment(postId, userId, request.content());
         Comment savedComment = commentRepository.save(comment);

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/FeedService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/FeedService.java
@@ -5,6 +5,7 @@ import com.prothsync.prothsync.dto.PostImageResponseDTO;
 import com.prothsync.prothsync.dto.PostResponseDTO;
 import com.prothsync.prothsync.entity.post.Post;
 import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.repository.repository.BlockRepository;
 import com.prothsync.prothsync.repository.repository.BookmarkRepository;
 import com.prothsync.prothsync.repository.repository.FollowRepository;
 import com.prothsync.prothsync.repository.repository.PostLikeRepository;
@@ -26,6 +27,7 @@ public class FeedService {
     private final HashtagService hashtagService;
     private final PostLikeRepository postLikeRepository;
     private final BookmarkRepository bookmarkRepository;
+    private final BlockRepository blockRepository;
 
     @Transactional(readOnly = true)
     public PageResponse<PostResponseDTO> getFollowingFeed(Long userId, Pageable pageable) {
@@ -37,6 +39,7 @@ public class FeedService {
 
         Page<Post> postPage = postRepository.findFeedPostsByUserIds(followingIds, pageable);
 
+        List<Long> blockedIds = blockRepository.findBlockedIdsByBlockerId(userId);
         List<PostResponseDTO> feedPosts = postPage.getContent().stream()
             .map(post -> buildPostResponseDTO(post, userId))
             .toList();

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/FollowService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/FollowService.java
@@ -26,6 +26,7 @@ public class FollowService {
     private final FollowRepository followRepository;
     private final UserRepository userRepository;
     private final NotificationService notificationService;
+    private final BlockService blockService;
 
     @Transactional
     public FollowResponseDTO toggleFollow(Long followerId, Long followingId) {
@@ -43,6 +44,7 @@ public class FollowService {
             userRepository.save(following);
             return FollowResponseDTO.of(followingId, false, following.getFollowerCount());
         } else {
+            blockService.validateNotBlocked(followerId, followingId);
             Follow follow = Follow.create(followerId, followingId);
             followRepository.save(follow);
             follower.incrementFollowingCount();

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/LikeService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/LikeService.java
@@ -21,6 +21,7 @@ public class LikeService {
     private final PostLikeRepository postLikeRepository;
     private final PostRepository postRepository;
     private final NotificationService notificationService;
+    private final BlockService blockService;
 
     @Transactional
     public LikeResponseDTO toggleLike(Long postId, Long userId) {
@@ -34,6 +35,7 @@ public class LikeService {
             postRepository.save(post);
             return LikeResponseDTO.of(postId, false, post.getLikeCount());
         } else {
+            blockService.validateNotBlocked(userId, post.getUserId());
             PostLike postLike = PostLike.create(userId, postId);
             postLikeRepository.save(postLike);
             post.incrementLikeCount();

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/SearchService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/SearchService.java
@@ -10,6 +10,7 @@ import com.prothsync.prothsync.exception.BusinessException;
 import com.prothsync.prothsync.exception.PostErrorCode;
 import com.prothsync.prothsync.exception.SearchErrorCode;
 import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.repository.repository.BlockRepository;
 import com.prothsync.prothsync.repository.repository.HashtagRepository;
 import com.prothsync.prothsync.repository.repository.PostRepository;
 import com.prothsync.prothsync.repository.repository.UserRepository;
@@ -31,11 +32,8 @@ public class SearchService {
     private final PostRepository postRepository;
     private final UserRepository userRepository;
     private final PostImageService postImageService;
+    private final BlockRepository blockRepository;
 
-    /**
-     * 해시태그 자동완성 검색
-     * 접두사(StartingWith) 기반으로 매칭되는 해시태그를 usageCount 내림차순으로 반환
-     */
     public PageResponse<HashtagResponseDTO> searchHashtags(String keyword, Pageable pageable) {
         validateKeyword(keyword);
 
@@ -49,11 +47,9 @@ public class SearchService {
         return PageResponse.of(hashtags, hashtagPage);
     }
 
-    /**
-     * 해시태그 기반 게시물 검색
-     * 해시태그 이름 → 해시태그 ID 변환 → 해당 해시태그가 달린 PUBLIC 게시물 조회
-     */
-    public PageResponse<PostSummaryResponseDTO> searchPostsByHashtag(String hashtagName, Pageable pageable) {
+    public PageResponse<PostSummaryResponseDTO> searchPostsByHashtag(
+        String hashtagName, Long currentUserId, Pageable pageable) {
+
         validateKeyword(hashtagName);
 
         String normalizedName = normalizeHashtagKeyword(hashtagName);
@@ -64,7 +60,10 @@ public class SearchService {
         Page<Post> postPage = postRepository.findAllByHashtagIdAndVisibilityPublic(
             hashtag.getHashtagId(), pageable);
 
+        List<Long> blockedIds = getBlockedIds(currentUserId);
+
         List<PostSummaryResponseDTO> summaries = postPage.getContent().stream()
+            .filter(post -> !blockedIds.contains(post.getUserId()))
             .map(post -> PostSummaryResponseDTO.of(
                 post, postImageService.getThumbnailUrl(post.getPostId())))
             .toList();
@@ -72,16 +71,19 @@ public class SearchService {
         return PageResponse.of(summaries, postPage);
     }
 
-    /**
-     * 사용자 닉네임 검색
-     * 포함(Containing) 기반, 대소문자 무시
-     */
-    public PageResponse<UserSearchResponseDTO> searchUsers(String keyword, Pageable pageable) {
+
+
+    public PageResponse<UserSearchResponseDTO> searchUsers(
+        String keyword, Long currentUserId, Pageable pageable) {
+
         validateKeyword(keyword);
 
         Page<User> userPage = userRepository.searchByNickName(keyword.trim(), pageable);
 
+        List<Long> blockedIds = getBlockedIds(currentUserId);
+
         List<UserSearchResponseDTO> users = userPage.getContent().stream()
+            .filter(user -> !blockedIds.contains(user.getUserId()))
             .map(UserSearchResponseDTO::from)
             .toList();
 
@@ -97,13 +99,16 @@ public class SearchService {
         }
     }
 
-    /**
-     * 해시태그 키워드 정규화
-     * '#' 접두사 제거 및 소문자 변환 (Hashtag 엔티티의 정규화 로직과 동일)
-     */
     private String normalizeHashtagKeyword(String keyword) {
         return keyword.trim()
             .replaceAll("^#+", "")
             .toLowerCase();
+    }
+
+    private List<Long> getBlockedIds(Long currentUserId) {
+        if (currentUserId == null) {
+            return List.of();
+        }
+        return blockRepository.findBlockedIdsByBlockerId(currentUserId);
     }
 }


### PR DESCRIPTION
# 변경사항
- 사용자 간 차단 기능을 구현하고, 차단 관계가 플랫폼 전반에 반영되도록 기존 서비스들에 필터링을 적용했습니다.
- 차단하면 양방향 팔로우가 자동 해제되고, 이후 팔로우/좋아요/댓글 등의 상호작용이 차단되며, 피드와 검색 결과에서도 해당 사용자의 콘텐츠가 제외됩니다.
