### PR TITLE
feat: 신고 기능 구현

### DIFF
--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/ReportController.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/ReportController.java
@@ -1,0 +1,47 @@
+package com.prothsync.prothsync.controller;
+
+import com.prothsync.prothsync.controller.docs.ReportControllerDocs;
+import com.prothsync.prothsync.dto.ReportCreateRequestDTO;
+import com.prothsync.prothsync.dto.ReportResponseDTO;
+import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.security.CustomUserDetails;
+import com.prothsync.prothsync.service.ReportService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/reports")
+public class ReportController implements ReportControllerDocs {
+
+    private final ReportService reportService;
+
+    @PostMapping
+    public ResponseEntity<ReportResponseDTO> createReport(
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        @Valid @RequestBody ReportCreateRequestDTO request
+    ) {
+        ReportResponseDTO response = reportService.createReport(
+            userDetails.getUserId(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping("/my")
+    public ResponseEntity<PageResponse<ReportResponseDTO>> getMyReports(
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        Pageable pageable
+    ) {
+        PageResponse<ReportResponseDTO> response = reportService.getMyReports(
+            userDetails.getUserId(), pageable);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/ReportControllerDocs.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/ReportControllerDocs.java
@@ -1,0 +1,75 @@
+package com.prothsync.prothsync.controller.docs;
+
+import com.prothsync.prothsync.dto.ReportCreateRequestDTO;
+import com.prothsync.prothsync.dto.ReportResponseDTO;
+import com.prothsync.prothsync.exception.ErrorResponse;
+import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "신고", description = "신고 API")
+@SecurityRequirement(name = "bearerAuth")
+public interface ReportControllerDocs {
+
+    @Operation(
+        summary = "신고 접수",
+        description = "게시글, 댓글, 사용자, 의뢰를 신고합니다. "
+            + "자기 자신 또는 자신의 콘텐츠는 신고할 수 없으며, 동일 대상에 대해 중복 신고가 불가합니다."
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "201",
+            description = "신고 접수 성공",
+            content = @Content(schema = @Schema(implementation = ReportResponseDTO.class))
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "자기 자신을 신고할 수 없음 / 필수 값 누락",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description = "인증 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "신고 대상을 찾을 수 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description = "이미 신고한 대상",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<ReportResponseDTO> createReport(
+        CustomUserDetails userDetails,
+        ReportCreateRequestDTO request
+    );
+
+    @Operation(
+        summary = "내 신고 내역 조회",
+        description = "내가 접수한 신고 목록을 페이징하여 조회합니다. 처리 상태(PENDING/ACCEPTED/REJECTED)를 확인할 수 있습니다."
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공"),
+        @ApiResponse(
+            responseCode = "401",
+            description = "인증 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<PageResponse<ReportResponseDTO>> getMyReports(
+        CustomUserDetails userDetails,
+        Pageable pageable
+    );
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/dto/ReportCreateRequestDTO.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/dto/ReportCreateRequestDTO.java
@@ -1,0 +1,23 @@
+package com.prothsync.prothsync.dto;
+
+import com.prothsync.prothsync.entity.report.ReportReason;
+import com.prothsync.prothsync.entity.report.ReportTargetType;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record ReportCreateRequestDTO(
+
+    @NotNull(message = "신고 대상 유형은 필수입니다.")
+    ReportTargetType targetType,
+
+    @NotNull(message = "신고 대상 ID는 필수입니다.")
+    Long targetId,
+
+    @NotNull(message = "신고 사유는 필수입니다.")
+    ReportReason reason,
+
+    @Size(max = 500, message = "상세 사유는 500자를 초과할 수 없습니다.")
+    String description
+) {
+
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/dto/ReportResponseDTO.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/dto/ReportResponseDTO.java
@@ -1,0 +1,36 @@
+package com.prothsync.prothsync.dto;
+
+import com.prothsync.prothsync.entity.report.Report;
+import com.prothsync.prothsync.entity.report.ReportReason;
+import com.prothsync.prothsync.entity.report.ReportStatus;
+import com.prothsync.prothsync.entity.report.ReportTargetType;
+import java.time.LocalDateTime;
+
+public record ReportResponseDTO(
+    Long reportId,
+    Long reporterId,
+    ReportTargetType targetType,
+    Long targetId,
+    ReportReason reason,
+    String description,
+    ReportStatus status,
+    Long processedBy,
+    LocalDateTime processedAt,
+    LocalDateTime createdAt
+) {
+
+    public static ReportResponseDTO from(Report report) {
+        return new ReportResponseDTO(
+            report.getReportId(),
+            report.getReporterId(),
+            report.getTargetType(),
+            report.getTargetId(),
+            report.getReason(),
+            report.getDescription(),
+            report.getStatus(),
+            report.getProcessedBy(),
+            report.getProcessedAt(),
+            report.getCreatedAt()
+        );
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/report/Report.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/report/Report.java
@@ -1,0 +1,134 @@
+package com.prothsync.prothsync.entity.report;
+
+import com.prothsync.prothsync.common.BaseEntity;
+import com.prothsync.prothsync.exception.BusinessException;
+import com.prothsync.prothsync.exception.ReportErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+    name = "reports",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_reports_reporter_target",
+            columnNames = {"reporter_id", "target_type", "target_id"}
+        )
+    }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Report extends BaseEntity {
+
+    private static final int MAX_DESCRIPTION_LENGTH = 500;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long reportId;
+
+    @Column(name = "reporter_id", nullable = false)
+    private Long reporterId;
+
+    @Column(name = "target_type", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ReportTargetType targetType;
+
+    @Column(name = "target_id", nullable = false)
+    private Long targetId;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ReportReason reason;
+
+    @Column(length = 500)
+    private String description;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ReportStatus status;
+
+    @Column
+    private Long processedBy;
+
+    @Column
+    private LocalDateTime processedAt;
+
+    private Report(Long reporterId, ReportTargetType targetType, Long targetId,
+        ReportReason reason, String description) {
+        this.reporterId = reporterId;
+        this.targetType = targetType;
+        this.targetId = targetId;
+        this.reason = reason;
+        this.description = description;
+        this.status = ReportStatus.PENDING;
+    }
+
+    public static Report create(Long reporterId, ReportTargetType targetType, Long targetId,
+        ReportReason reason, String description) {
+        validateReporterId(reporterId);
+        validateTargetType(targetType);
+        validateTargetId(targetId);
+        validateReason(reason);
+        validateDescription(description);
+
+        return new Report(reporterId, targetType, targetId, reason, description);
+    }
+
+    public void process(Long adminId, ReportStatus status) {
+        validateProcessStatus(status);
+        this.processedBy = adminId;
+        this.processedAt = LocalDateTime.now();
+        this.status = status;
+    }
+
+    public boolean isPending() {
+        return this.status == ReportStatus.PENDING;
+    }
+
+    private static void validateReporterId(Long reporterId) {
+        if (reporterId == null) {
+            throw new BusinessException(ReportErrorCode.REPORTER_ID_NULL);
+        }
+    }
+
+    private static void validateTargetType(ReportTargetType targetType) {
+        if (targetType == null) {
+            throw new BusinessException(ReportErrorCode.TARGET_TYPE_NULL);
+        }
+    }
+
+    private static void validateTargetId(Long targetId) {
+        if (targetId == null) {
+            throw new BusinessException(ReportErrorCode.TARGET_ID_NULL);
+        }
+    }
+
+    private static void validateReason(ReportReason reason) {
+        if (reason == null) {
+            throw new BusinessException(ReportErrorCode.REASON_NULL);
+        }
+    }
+
+    private static void validateDescription(String description) {
+        if (description != null && description.length() > MAX_DESCRIPTION_LENGTH) {
+            throw new BusinessException(ReportErrorCode.DESCRIPTION_TOO_LONG);
+        }
+    }
+
+    private static void validateProcessStatus(ReportStatus status) {
+        if (status == null || status == ReportStatus.PENDING) {
+            throw new BusinessException(ReportErrorCode.INVALID_PROCESS_STATUS);
+        }
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/report/ReportReason.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/report/ReportReason.java
@@ -1,0 +1,17 @@
+package com.prothsync.prothsync.entity.report;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReportReason {
+
+    SPAM("스팸/광고"),
+    INAPPROPRIATE("부적절한 콘텐츠"),
+    HARASSMENT("괴롭힘/따돌림"),
+    COPYRIGHT("저작권 침해"),
+    OTHER("기타");
+
+    private final String description;
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/report/ReportStatus.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/report/ReportStatus.java
@@ -1,0 +1,7 @@
+package com.prothsync.prothsync.entity.report;
+
+public enum ReportStatus {
+    PENDING,
+    ACCEPTED,
+    REJECTED
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/report/ReportTargetType.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/report/ReportTargetType.java
@@ -1,0 +1,8 @@
+package com.prothsync.prothsync.entity.report;
+
+public enum ReportTargetType {
+    POST,
+    COMMENT,
+    USER,
+    CASE_REQUEST
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/exception/ReportErrorCode.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/exception/ReportErrorCode.java
@@ -1,0 +1,26 @@
+package com.prothsync.prothsync.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReportErrorCode implements ErrorCode {
+
+    REPORTER_ID_NULL(HttpStatus.BAD_REQUEST, "신고자 ID가 NULL 입니다."),
+    TARGET_TYPE_NULL(HttpStatus.BAD_REQUEST, "신고 대상 유형이 NULL 입니다."),
+    TARGET_ID_NULL(HttpStatus.BAD_REQUEST, "신고 대상 ID가 NULL 입니다."),
+    REASON_NULL(HttpStatus.BAD_REQUEST, "신고 사유가 NULL 입니다."),
+    DESCRIPTION_TOO_LONG(HttpStatus.BAD_REQUEST, "신고 상세 사유는 500자를 초과할 수 없습니다."),
+    CANNOT_REPORT_SELF(HttpStatus.BAD_REQUEST, "자기 자신을 신고할 수 없습니다."),
+    ALREADY_REPORTED(HttpStatus.CONFLICT, "이미 신고한 대상입니다."),
+    REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "신고 정보를 찾을 수 없습니다."),
+    REPORT_TARGET_NOT_FOUND(HttpStatus.NOT_FOUND, "신고 대상을 찾을 수 없습니다."),
+    INVALID_PROCESS_STATUS(HttpStatus.BAD_REQUEST, "처리 상태는 ACCEPTED 또는 REJECTED만 가능합니다."),
+    REPORT_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "이미 처리된 신고입니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/ReportRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/ReportRepositoryImpl.java
@@ -1,0 +1,51 @@
+package com.prothsync.prothsync.repository.impl;
+
+import com.prothsync.prothsync.entity.report.Report;
+import com.prothsync.prothsync.entity.report.ReportStatus;
+import com.prothsync.prothsync.entity.report.ReportTargetType;
+import com.prothsync.prothsync.repository.jpa.ReportJpaRepository;
+import com.prothsync.prothsync.repository.repository.ReportRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ReportRepositoryImpl implements ReportRepository {
+
+    private final ReportJpaRepository reportJpaRepository;
+
+    @Override
+    public Report save(Report report) {
+        return reportJpaRepository.save(report);
+    }
+
+    @Override
+    public Optional<Report> findById(Long reportId) {
+        return reportJpaRepository.findById(reportId);
+    }
+
+    @Override
+    public boolean existsByReporterIdAndTargetTypeAndTargetId(
+        Long reporterId, ReportTargetType targetType, Long targetId) {
+        return reportJpaRepository.existsByReporterIdAndTargetTypeAndTargetId(
+            reporterId, targetType, targetId);
+    }
+
+    @Override
+    public Page<Report> findAllByReporterId(Long reporterId, Pageable pageable) {
+        return reportJpaRepository.findAllByReporterId(reporterId, pageable);
+    }
+
+    @Override
+    public Page<Report> findAllByStatus(ReportStatus status, Pageable pageable) {
+        return reportJpaRepository.findAllByStatus(status, pageable);
+    }
+
+    @Override
+    public long countByStatus(ReportStatus status) {
+        return reportJpaRepository.countByStatus(status);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/ReportJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/ReportJpaRepository.java
@@ -1,0 +1,21 @@
+package com.prothsync.prothsync.repository.jpa;
+
+import com.prothsync.prothsync.entity.report.Report;
+import com.prothsync.prothsync.entity.report.ReportStatus;
+import com.prothsync.prothsync.entity.report.ReportTargetType;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportJpaRepository extends JpaRepository<Report, Long> {
+
+    boolean existsByReporterIdAndTargetTypeAndTargetId(
+        Long reporterId, ReportTargetType targetType, Long targetId);
+
+    Page<Report> findAllByReporterId(Long reporterId, Pageable pageable);
+
+    Page<Report> findAllByStatus(ReportStatus status, Pageable pageable);
+
+    long countByStatus(ReportStatus status);
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/ReportRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/ReportRepository.java
@@ -1,0 +1,24 @@
+package com.prothsync.prothsync.repository.repository;
+
+import com.prothsync.prothsync.entity.report.Report;
+import com.prothsync.prothsync.entity.report.ReportStatus;
+import com.prothsync.prothsync.entity.report.ReportTargetType;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ReportRepository {
+
+    Report save(Report report);
+
+    Optional<Report> findById(Long reportId);
+
+    boolean existsByReporterIdAndTargetTypeAndTargetId(
+        Long reporterId, ReportTargetType targetType, Long targetId);
+
+    Page<Report> findAllByReporterId(Long reporterId, Pageable pageable);
+
+    Page<Report> findAllByStatus(ReportStatus status, Pageable pageable);
+
+    long countByStatus(ReportStatus status);
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/ReportService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/ReportService.java
@@ -1,0 +1,106 @@
+package com.prothsync.prothsync.service;
+
+import com.prothsync.prothsync.dto.ReportCreateRequestDTO;
+import com.prothsync.prothsync.dto.ReportResponseDTO;
+import com.prothsync.prothsync.entity.report.Report;
+import com.prothsync.prothsync.entity.report.ReportTargetType;
+import com.prothsync.prothsync.exception.BusinessException;
+import com.prothsync.prothsync.exception.PostErrorCode;
+import com.prothsync.prothsync.exception.ReportErrorCode;
+import com.prothsync.prothsync.exception.UserErrorCode;
+import com.prothsync.prothsync.exception.CaseErrorCode;
+import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.repository.repository.CaseRequestRepository;
+import com.prothsync.prothsync.repository.repository.CommentRepository;
+import com.prothsync.prothsync.repository.repository.PostRepository;
+import com.prothsync.prothsync.repository.repository.ReportRepository;
+import com.prothsync.prothsync.repository.repository.UserRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+
+    private final ReportRepository reportRepository;
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+    private final CaseRequestRepository caseRequestRepository;
+
+    @Transactional
+    public ReportResponseDTO createReport(Long reporterId, ReportCreateRequestDTO request) {
+        if (request.targetType() == ReportTargetType.USER
+            && reporterId.equals(request.targetId())) {
+            throw new BusinessException(ReportErrorCode.CANNOT_REPORT_SELF);
+        }
+
+        validateTargetExists(request.targetType(), request.targetId());
+        validateNotSelfReport(reporterId, request.targetType(), request.targetId());
+
+        if (reportRepository.existsByReporterIdAndTargetTypeAndTargetId(
+            reporterId, request.targetType(), request.targetId())) {
+            throw new BusinessException(ReportErrorCode.ALREADY_REPORTED);
+        }
+
+        Report report = Report.create(
+            reporterId,
+            request.targetType(),
+            request.targetId(),
+            request.reason(),
+            request.description()
+        );
+
+        Report savedReport = reportRepository.save(report);
+        return ReportResponseDTO.from(savedReport);
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponse<ReportResponseDTO> getMyReports(Long reporterId, Pageable pageable) {
+        Page<Report> reportPage = reportRepository.findAllByReporterId(reporterId, pageable);
+
+        List<ReportResponseDTO> reports = reportPage.getContent().stream()
+            .map(ReportResponseDTO::from)
+            .toList();
+
+        return PageResponse.of(reports, reportPage);
+    }
+
+    private void validateTargetExists(ReportTargetType targetType, Long targetId) {
+        switch (targetType) {
+            case USER -> userRepository.findById(targetId)
+                .orElseThrow(() -> new BusinessException(ReportErrorCode.REPORT_TARGET_NOT_FOUND));
+            case POST -> postRepository.findById(targetId)
+                .orElseThrow(() -> new BusinessException(ReportErrorCode.REPORT_TARGET_NOT_FOUND));
+            case COMMENT -> commentRepository.findById(targetId)
+                .orElseThrow(() -> new BusinessException(ReportErrorCode.REPORT_TARGET_NOT_FOUND));
+            case CASE_REQUEST -> caseRequestRepository.findById(targetId)
+                .orElseThrow(() -> new BusinessException(ReportErrorCode.REPORT_TARGET_NOT_FOUND));
+        }
+    }
+
+    private void validateNotSelfReport(Long reporterId, ReportTargetType targetType, Long targetId) {
+        Long ownerId = null;
+
+        switch (targetType) {
+            case POST -> ownerId = postRepository.findById(targetId)
+                .map(post -> post.getUserId())
+                .orElse(null);
+            case COMMENT -> ownerId = commentRepository.findById(targetId)
+                .map(comment -> comment.getUserId())
+                .orElse(null);
+            case CASE_REQUEST -> ownerId = caseRequestRepository.findById(targetId)
+                .map(caseRequest -> caseRequest.getClientId())
+                .orElse(null);
+            default -> { return; }
+        }
+
+        if (reporterId.equals(ownerId)) {
+            throw new BusinessException(ReportErrorCode.CANNOT_REPORT_SELF);
+        }
+    }
+}


### PR DESCRIPTION
# 변경사항
- 게시글, 댓글, 사용자, 의뢰를 신고할 수 있는 신고 시스템을 구현했습니다.
- 신고가 접수되면 PENDING 상태로 저장되며, 이후 관리자 처리 하는 구조입니다.
- 이번 PR 에서는 신고 기능만 구현 하고 다음에는 관리자 기능을 구현할 예정입니다.

## 주요 사항
### 중복 신고 방지 전략
- uniqueConstraint를 설정하여 동일 사용자가 같은 대상을 여러 번 신고하는 것을 DB 레벨에서 방지합니다.
- 서비스 레이어에서도 existsByReporterIdAndTargetTypeAndTargetId()로 사전 체크하여 ALREADY_REPORTED (409) 에러를 명확하게 반환합니다. 즉 DB 제약조건은 최후의 안전장치이고, 서비스 레이어에서 먼저 친절한 에러 메시지를 제공합니다.

