### PR TITLE
feat: 관리자 기능 구현

### DIFF
--- a/prothsync/src/main/java/com/prothsync/prothsync/config/SecurityConfig.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/config/SecurityConfig.java
@@ -57,6 +57,8 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/api/cases").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/cases/category/**").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/cases/{caseRequestId}").permitAll()
+                // Admin - 관리자 권한 필요
+                .requestMatchers("/api/admin/**").hasRole("ADMIN")
                 // 나머지는 인증 필요
                 .anyRequest().authenticated()
             )

--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/AdminController.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/AdminController.java
@@ -1,0 +1,131 @@
+package com.prothsync.prothsync.controller;
+
+import com.prothsync.prothsync.controller.docs.AdminControllerDocs;
+import com.prothsync.prothsync.dto.AdminDashboardResponseDTO;
+import com.prothsync.prothsync.dto.AdminUserResponseDTO;
+import com.prothsync.prothsync.dto.ReportProcessRequestDTO;
+import com.prothsync.prothsync.dto.ReportResponseDTO;
+import com.prothsync.prothsync.dto.UserRoleUpdateRequestDTO;
+import com.prothsync.prothsync.dto.UserSuspendRequestDTO;
+import com.prothsync.prothsync.entity.report.ReportStatus;
+import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.security.CustomUserDetails;
+import com.prothsync.prothsync.service.AdminService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin")
+public class AdminController implements AdminControllerDocs {
+
+    private final AdminService adminService;
+
+    @GetMapping("/reports")
+    public ResponseEntity<PageResponse<ReportResponseDTO>> getReports(
+        @RequestParam(required = false) ReportStatus status,
+        Pageable pageable
+    ) {
+        PageResponse<ReportResponseDTO> response = adminService.getReports(status, pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/reports/{reportId}")
+    public ResponseEntity<ReportResponseDTO> getReport(
+        @PathVariable Long reportId
+    ) {
+        ReportResponseDTO response = adminService.getReport(reportId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/reports/{reportId}")
+    public ResponseEntity<ReportResponseDTO> processReport(
+        @PathVariable Long reportId,
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        @Valid @RequestBody ReportProcessRequestDTO request
+    ) {
+        ReportResponseDTO response = adminService.processReport(
+            reportId, userDetails.getUserId(), request);
+        return ResponseEntity.ok(response);
+    }
+
+
+    @GetMapping("/users")
+    public ResponseEntity<PageResponse<AdminUserResponseDTO>> getUsers(
+        Pageable pageable
+    ) {
+        PageResponse<AdminUserResponseDTO> response = adminService.getUsers(pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/users/{userId}/suspend")
+    public ResponseEntity<AdminUserResponseDTO> suspendUser(
+        @PathVariable Long userId,
+        @Valid @RequestBody UserSuspendRequestDTO request
+    ) {
+        AdminUserResponseDTO response = adminService.suspendUser(userId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/users/{userId}/unsuspend")
+    public ResponseEntity<AdminUserResponseDTO> unsuspendUser(
+        @PathVariable Long userId
+    ) {
+        AdminUserResponseDTO response = adminService.unsuspendUser(userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/users/{userId}/role")
+    public ResponseEntity<AdminUserResponseDTO> updateUserRole(
+        @PathVariable Long userId,
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        @Valid @RequestBody UserRoleUpdateRequestDTO request
+    ) {
+        AdminUserResponseDTO response = adminService.updateUserRole(
+            userId, userDetails.getUserId(), request);
+        return ResponseEntity.ok(response);
+    }
+
+
+    @DeleteMapping("/posts/{postId}")
+    public ResponseEntity<Void> deletePost(
+        @PathVariable Long postId
+    ) {
+        adminService.deletePost(postId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/comments/{commentId}")
+    public ResponseEntity<Void> deleteComment(
+        @PathVariable Long commentId
+    ) {
+        adminService.deleteComment(commentId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/cases/{caseRequestId}")
+    public ResponseEntity<Void> deleteCaseRequest(
+        @PathVariable Long caseRequestId
+    ) {
+        adminService.deleteCaseRequest(caseRequestId);
+        return ResponseEntity.noContent().build();
+    }
+
+
+    @GetMapping("/dashboard/stats")
+    public ResponseEntity<AdminDashboardResponseDTO> getDashboardStats() {
+        AdminDashboardResponseDTO response = adminService.getDashboardStats();
+        return ResponseEntity.ok(response);
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/AdminControllerDocs.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/AdminControllerDocs.java
@@ -1,0 +1,141 @@
+package com.prothsync.prothsync.controller.docs;
+
+import com.prothsync.prothsync.dto.AdminDashboardResponseDTO;
+import com.prothsync.prothsync.dto.AdminUserResponseDTO;
+import com.prothsync.prothsync.dto.ReportProcessRequestDTO;
+import com.prothsync.prothsync.dto.ReportResponseDTO;
+import com.prothsync.prothsync.dto.UserRoleUpdateRequestDTO;
+import com.prothsync.prothsync.dto.UserSuspendRequestDTO;
+import com.prothsync.prothsync.entity.report.ReportStatus;
+import com.prothsync.prothsync.exception.ErrorResponse;
+import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "관리자", description = "관리자 전용 API (ADMIN 권한 필요)")
+@SecurityRequirement(name = "bearerAuth")
+public interface AdminControllerDocs {
+
+
+    @Operation(summary = "신고 목록 조회", description = "신고 목록을 상태별로 필터링하여 조회합니다. 상태 미지정 시 PENDING 목록을 반환합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공"),
+        @ApiResponse(responseCode = "403", description = "관리자 권한 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<PageResponse<ReportResponseDTO>> getReports(
+        @Parameter(description = "신고 상태 필터 (PENDING, ACCEPTED, REJECTED)") ReportStatus status,
+        Pageable pageable
+    );
+
+    @Operation(summary = "신고 상세 조회", description = "특정 신고의 상세 정보를 조회합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공"),
+        @ApiResponse(responseCode = "404", description = "신고를 찾을 수 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<ReportResponseDTO> getReport(
+        @Parameter(description = "신고 ID") Long reportId
+    );
+
+    @Operation(summary = "신고 처리", description = "신고를 수락(ACCEPTED) 또는 거절(REJECTED)로 처리합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "처리 성공"),
+        @ApiResponse(responseCode = "400", description = "이미 처리된 신고 / 잘못된 상태값",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "신고를 찾을 수 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<ReportResponseDTO> processReport(
+        @Parameter(description = "신고 ID") Long reportId,
+        CustomUserDetails userDetails,
+        ReportProcessRequestDTO request
+    );
+
+
+    @Operation(summary = "전체 사용자 목록 조회", description = "전체 사용자를 페이징하여 조회합니다. 정지 상태, 권한 정보가 포함됩니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    ResponseEntity<PageResponse<AdminUserResponseDTO>> getUsers(Pageable pageable);
+
+    @Operation(summary = "계정 정지", description = "대상 사용자의 계정을 정지합니다. 관리자 계정은 정지할 수 없습니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "정지 성공"),
+        @ApiResponse(responseCode = "400", description = "관리자 계정 정지 불가 / 이미 정지된 사용자",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<AdminUserResponseDTO> suspendUser(
+        @Parameter(description = "대상 사용자 ID") Long userId,
+        UserSuspendRequestDTO request
+    );
+
+    @Operation(summary = "정지 해제", description = "정지된 사용자의 계정을 복원합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "해제 성공"),
+        @ApiResponse(responseCode = "400", description = "정지 상태가 아닌 사용자",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<AdminUserResponseDTO> unsuspendUser(
+        @Parameter(description = "대상 사용자 ID") Long userId
+    );
+
+    @Operation(summary = "사용자 권한 변경", description = "사용자의 권한을 ADMIN 또는 USER로 변경합니다. 자신의 권한은 변경할 수 없습니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "변경 성공"),
+        @ApiResponse(responseCode = "400", description = "자신의 권한 변경 불가",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<AdminUserResponseDTO> updateUserRole(
+        @Parameter(description = "대상 사용자 ID") Long userId,
+        CustomUserDetails userDetails,
+        UserRoleUpdateRequestDTO request
+    );
+
+
+    @Operation(summary = "게시글 강제 삭제", description = "관리자 권한으로 게시글을 삭제합니다. 관련 좋아요, 북마크, 댓글, 해시태그, 이미지가 함께 삭제됩니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "삭제 성공"),
+        @ApiResponse(responseCode = "404", description = "게시글을 찾을 수 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<Void> deletePost(@Parameter(description = "게시글 ID") Long postId);
+
+    @Operation(summary = "댓글 강제 삭제", description = "관리자 권한으로 댓글을 삭제합니다. 게시글의 댓글 수가 자동으로 감소합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "삭제 성공"),
+        @ApiResponse(responseCode = "404", description = "댓글을 찾을 수 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<Void> deleteComment(@Parameter(description = "댓글 ID") Long commentId);
+
+    @Operation(summary = "의뢰 강제 삭제", description = "관리자 권한으로 의뢰를 삭제합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "삭제 성공"),
+        @ApiResponse(responseCode = "404", description = "의뢰를 찾을 수 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<Void> deleteCaseRequest(@Parameter(description = "의뢰 ID") Long caseRequestId);
+
+
+    @Operation(summary = "대시보드 통계 조회", description = "총 사용자 수, 게시글 수, 의뢰 수, 신고 현황 등 플랫폼 전체 통계를 조회합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    ResponseEntity<AdminDashboardResponseDTO> getDashboardStats();
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/dto/AdminDashboardResponseDTO.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/dto/AdminDashboardResponseDTO.java
@@ -1,0 +1,29 @@
+package com.prothsync.prothsync.dto;
+
+public record AdminDashboardResponseDTO(
+    long totalUsers,
+    long totalPosts,
+    long totalCaseRequests,
+    long pendingReports,
+    long acceptedReports,
+    long rejectedReports
+) {
+
+    public static AdminDashboardResponseDTO of(
+        long totalUsers,
+        long totalPosts,
+        long totalCaseRequests,
+        long pendingReports,
+        long acceptedReports,
+        long rejectedReports
+    ) {
+        return new AdminDashboardResponseDTO(
+            totalUsers,
+            totalPosts,
+            totalCaseRequests,
+            pendingReports,
+            acceptedReports,
+            rejectedReports
+        );
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/dto/AdminUserResponseDTO.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/dto/AdminUserResponseDTO.java
@@ -1,0 +1,37 @@
+package com.prothsync.prothsync.dto;
+
+import com.prothsync.prothsync.entity.user.User;
+import com.prothsync.prothsync.entity.user.UserRole;
+import com.prothsync.prothsync.entity.user.UserType;
+import java.time.LocalDateTime;
+
+public record AdminUserResponseDTO(
+    Long userId,
+    String userName,
+    String nickName,
+    String email,
+    UserType userType,
+    UserRole userRole,
+    boolean suspended,
+    LocalDateTime suspendedAt,
+    LocalDateTime suspendedUntil,
+    String suspendReason,
+    LocalDateTime createdAt
+) {
+
+    public static AdminUserResponseDTO from(User user) {
+        return new AdminUserResponseDTO(
+            user.getUserId(),
+            user.getUserName(),
+            user.getNickName(),
+            user.getEmail(),
+            user.getUserType(),
+            user.getUserRole(),
+            user.isSuspended(),
+            user.getSuspendedAt(),
+            user.getSuspendedUntil(),
+            user.getSuspendReason(),
+            user.getCreatedAt()
+        );
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/dto/ReportProcessRequestDTO.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/dto/ReportProcessRequestDTO.java
@@ -1,0 +1,12 @@
+package com.prothsync.prothsync.dto;
+
+import com.prothsync.prothsync.entity.report.ReportStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record ReportProcessRequestDTO(
+
+    @NotNull(message = "처리 상태는 필수입니다.")
+    ReportStatus status
+) {
+
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/dto/UserRoleUpdateRequestDTO.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/dto/UserRoleUpdateRequestDTO.java
@@ -1,0 +1,12 @@
+package com.prothsync.prothsync.dto;
+
+import com.prothsync.prothsync.entity.user.UserRole;
+import jakarta.validation.constraints.NotNull;
+
+public record UserRoleUpdateRequestDTO(
+
+    @NotNull(message = "변경할 권한은 필수입니다.")
+    UserRole role
+) {
+
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/dto/UserSuspendRequestDTO.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/dto/UserSuspendRequestDTO.java
@@ -1,0 +1,16 @@
+package com.prothsync.prothsync.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+
+public record UserSuspendRequestDTO(
+
+    @NotBlank(message = "정지 사유는 필수입니다.")
+    @Size(max = 500, message = "정지 사유는 500자를 초과할 수 없습니다.")
+    String reason,
+
+    LocalDateTime suspendUntil
+) {
+
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/user/User.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/user/User.java
@@ -12,6 +12,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -81,6 +82,15 @@ public class User extends BaseEntity {
 
     @Column(nullable = false)
     private int reviewCount = 0;
+
+    @Column
+    private LocalDateTime suspendedAt;
+
+    @Column
+    private LocalDateTime suspendedUntil;
+
+    @Column(length = 500)
+    private String suspendReason;
 
     private User(String userName,
         String password,
@@ -257,5 +267,28 @@ public class User extends BaseEntity {
     public void updateRatingStats(double averageRating, int reviewCount) {
         this.averageRating = averageRating;
         this.reviewCount = reviewCount;
+    }
+
+
+    public void suspend(String reason, LocalDateTime until) {
+        this.suspendedAt = LocalDateTime.now();
+        this.suspendedUntil = until;
+        this.suspendReason = reason;
+    }
+
+    public void unsuspend() {
+        this.suspendedAt = null;
+        this.suspendedUntil = null;
+        this.suspendReason = null;
+    }
+
+    public boolean isSuspended() {
+        if (this.suspendedAt == null) {
+            return false;
+        }
+        if (this.suspendedUntil != null && this.suspendedUntil.isBefore(LocalDateTime.now())) {
+            return false;
+        }
+        return true;
     }
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/exception/AdminErrorCode.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/exception/AdminErrorCode.java
@@ -1,0 +1,20 @@
+package com.prothsync.prothsync.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AdminErrorCode implements ErrorCode {
+
+    CANNOT_SUSPEND_ADMIN(HttpStatus.BAD_REQUEST, "관리자 계정은 정지할 수 없습니다."),
+    USER_NOT_SUSPENDED(HttpStatus.BAD_REQUEST, "정지 상태가 아닌 사용자입니다."),
+    USER_ALREADY_SUSPENDED(HttpStatus.CONFLICT, "이미 정지된 사용자입니다."),
+    CANNOT_CHANGE_OWN_ROLE(HttpStatus.BAD_REQUEST, "자신의 권한은 변경할 수 없습니다."),
+    SUSPEND_REASON_REQUIRED(HttpStatus.BAD_REQUEST, "정지 사유는 필수입니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/exception/CaseErrorCode.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/exception/CaseErrorCode.java
@@ -17,6 +17,7 @@ public enum CaseErrorCode implements ErrorCode {
     CASE_BUDGET_INVALID(HttpStatus.BAD_REQUEST, "예산은 0보다 커야 합니다."),
 
     CASE_NOT_FOUND(HttpStatus.NOT_FOUND, "의뢰를 찾을 수 없습니다."),
+    CASE_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "의뢰요청을 찾을 수 없습니다."),
     CASE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "의뢰에 접근할 권한이 없습니다."),
 
     CASE_NOT_OPEN(HttpStatus.CONFLICT, "모집중인 의뢰가 아닙니다."),

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/CaseRequestRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/CaseRequestRepositoryImpl.java
@@ -65,4 +65,9 @@ public class CaseRequestRepositoryImpl implements CaseRequestRepository {
         return caseRequestJpaRepository.findNearbyCasesByCategory(
             lat, lng, radiusKm, excludeUserId, category.name(), limit);
     }
+
+    @Override
+    public long count() {
+        return caseRequestJpaRepository.count();
+    }
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/PostRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/PostRepositoryImpl.java
@@ -62,4 +62,9 @@ public class PostRepositoryImpl implements PostRepository {
     public Page<Post> findAllByHashtagIdAndVisibilityPublic(Long hashtagId, Pageable pageable) {
         return postJpaRepository.findAllByHashtagIdAndVisibilityPublic(hashtagId, pageable);
     }
+
+    @Override
+    public long count() {
+        return postJpaRepository.count();
+    }
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/UserRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/UserRepositoryImpl.java
@@ -74,4 +74,14 @@ public class UserRepositoryImpl implements UserRepository {
     public Page<User> searchByNickName(String keyword, Pageable pageable) {
         return userJpaRepository.findByNickNameContainingIgnoreCase(keyword, pageable);
     }
+
+    @Override
+    public Page<User> findAll(Pageable pageable) {
+        return userJpaRepository.findAll(pageable);
+    }
+
+    @Override
+    public long count() {
+        return userJpaRepository.count();
+    }
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/UserJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/UserJpaRepository.java
@@ -102,4 +102,6 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
     );
 
     Page<User> findByNickNameContainingIgnoreCase(String keyword, Pageable pageable);
+
+    Page<User> findAll(Pageable pageable);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/CaseRequestRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/CaseRequestRepository.java
@@ -29,4 +29,6 @@ public interface CaseRequestRepository {
 
     List<CaseRequest> findNearbyCasesByCategory(double lat, double lng, double radiusKm,
         Long excludeUserId, CaseCategory category, int limit);
+
+    long count();
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/PostRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/PostRepository.java
@@ -23,4 +23,6 @@ public interface PostRepository {
     Page<Post> findFeedPostsByUserIds(List<Long> userIds, Pageable pageable);
 
     Page<Post> findAllByHashtagIdAndVisibilityPublic(Long hashtagId, Pageable pageable);
+
+    long count();
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/UserRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/UserRepository.java
@@ -23,4 +23,8 @@ public interface UserRepository {
         Long excludeUserId, String userType, int limit);
 
     Page<User> searchByNickName(String keyword, Pageable pageable);
+
+    Page<User> findAll(Pageable pageable);
+
+    long count();
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/security/CustomUserDetails.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/security/CustomUserDetails.java
@@ -37,7 +37,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public boolean isAccountNonLocked() {
-        return true;
+        return !user.isSuspended();
     }
 
     @Override

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/AdminService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/AdminService.java
@@ -1,0 +1,211 @@
+package com.prothsync.prothsync.service;
+
+import com.prothsync.prothsync.dto.AdminDashboardResponseDTO;
+import com.prothsync.prothsync.dto.AdminUserResponseDTO;
+import com.prothsync.prothsync.dto.ReportProcessRequestDTO;
+import com.prothsync.prothsync.dto.ReportResponseDTO;
+import com.prothsync.prothsync.dto.UserRoleUpdateRequestDTO;
+import com.prothsync.prothsync.dto.UserSuspendRequestDTO;
+import com.prothsync.prothsync.entity.post.Comment;
+import com.prothsync.prothsync.entity.post.Post;
+import com.prothsync.prothsync.entity.caserequest.CaseRequest;
+import com.prothsync.prothsync.entity.report.Report;
+import com.prothsync.prothsync.entity.report.ReportStatus;
+import com.prothsync.prothsync.entity.user.User;
+import com.prothsync.prothsync.entity.user.UserRole;
+import com.prothsync.prothsync.exception.AdminErrorCode;
+import com.prothsync.prothsync.exception.BusinessException;
+import com.prothsync.prothsync.exception.CaseErrorCode;
+import com.prothsync.prothsync.exception.PostErrorCode;
+import com.prothsync.prothsync.exception.ReportErrorCode;
+import com.prothsync.prothsync.exception.UserErrorCode;
+import com.prothsync.prothsync.global.PageResponse;
+import com.prothsync.prothsync.repository.repository.BookmarkRepository;
+import com.prothsync.prothsync.repository.repository.CaseRequestRepository;
+import com.prothsync.prothsync.repository.repository.CommentRepository;
+import com.prothsync.prothsync.repository.repository.PostLikeRepository;
+import com.prothsync.prothsync.repository.repository.PostRepository;
+import com.prothsync.prothsync.repository.repository.ReportRepository;
+import com.prothsync.prothsync.repository.repository.UserRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+
+    private final ReportRepository reportRepository;
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+    private final CaseRequestRepository caseRequestRepository;
+    private final PostLikeRepository postLikeRepository;
+    private final BookmarkRepository bookmarkRepository;
+    private final HashtagService hashtagService;
+    private final PostImageService postImageService;
+    private final CommentService commentService;
+
+    @Transactional(readOnly = true)
+    public PageResponse<ReportResponseDTO> getReports(ReportStatus status, Pageable pageable) {
+        Page<Report> reportPage;
+
+        if (status != null) {
+            reportPage = reportRepository.findAllByStatus(status, pageable);
+        } else {
+            reportPage = reportRepository.findAllByStatus(ReportStatus.PENDING, pageable);
+        }
+
+        List<ReportResponseDTO> reports = reportPage.getContent().stream()
+            .map(ReportResponseDTO::from)
+            .toList();
+
+        return PageResponse.of(reports, reportPage);
+    }
+
+    @Transactional(readOnly = true)
+    public ReportResponseDTO getReport(Long reportId) {
+        Report report = findReportOrThrow(reportId);
+        return ReportResponseDTO.from(report);
+    }
+
+    @Transactional
+    public ReportResponseDTO processReport(Long reportId, Long adminId, ReportProcessRequestDTO request) {
+        Report report = findReportOrThrow(reportId);
+
+        if (!report.isPending()) {
+            throw new BusinessException(ReportErrorCode.REPORT_ALREADY_PROCESSED);
+        }
+
+        report.process(adminId, request.status());
+        Report processedReport = reportRepository.save(report);
+
+        return ReportResponseDTO.from(processedReport);
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponse<AdminUserResponseDTO> getUsers(Pageable pageable) {
+        Page<User> userPage = userRepository.findAll(pageable);
+
+        List<AdminUserResponseDTO> users = userPage.getContent().stream()
+            .map(AdminUserResponseDTO::from)
+            .toList();
+
+        return PageResponse.of(users, userPage);
+    }
+
+    @Transactional
+    public AdminUserResponseDTO suspendUser(Long userId, UserSuspendRequestDTO request) {
+        User user = findUserOrThrow(userId);
+
+        if (user.isAdmin()) {
+            throw new BusinessException(AdminErrorCode.CANNOT_SUSPEND_ADMIN);
+        }
+        if (user.isSuspended()) {
+            throw new BusinessException(AdminErrorCode.USER_ALREADY_SUSPENDED);
+        }
+
+        user.suspend(request.reason(), request.suspendUntil());
+        userRepository.save(user);
+
+        return AdminUserResponseDTO.from(user);
+    }
+
+    @Transactional
+    public AdminUserResponseDTO unsuspendUser(Long userId) {
+        User user = findUserOrThrow(userId);
+
+        if (!user.isSuspended()) {
+            throw new BusinessException(AdminErrorCode.USER_NOT_SUSPENDED);
+        }
+
+        user.unsuspend();
+        userRepository.save(user);
+
+        return AdminUserResponseDTO.from(user);
+    }
+
+    @Transactional
+    public AdminUserResponseDTO updateUserRole(Long userId, Long adminId, UserRoleUpdateRequestDTO request) {
+        if (userId.equals(adminId)) {
+            throw new BusinessException(AdminErrorCode.CANNOT_CHANGE_OWN_ROLE);
+        }
+
+        User user = findUserOrThrow(userId);
+
+        if (request.role() == UserRole.ADMIN) {
+            user.promoteToAdmin();
+        } else {
+            user.demoteToUser();
+        }
+
+        userRepository.save(user);
+        return AdminUserResponseDTO.from(user);
+    }
+
+
+    @Transactional
+    public void deletePost(Long postId) {
+        Post post = postRepository.findById(postId)
+            .orElseThrow(() -> new BusinessException(PostErrorCode.POST_NOT_FOUND));
+
+        postLikeRepository.deleteAllByPostId(postId);
+        bookmarkRepository.deleteAllByPostId(postId);
+        commentService.deleteAllByPostId(postId);
+        hashtagService.removeAllHashtagsFromPost(postId);
+        postImageService.deleteAllByPostId(postId);
+        postRepository.delete(post);
+    }
+
+    @Transactional
+    public void deleteComment(Long commentId) {
+        Comment comment = commentRepository.findById(commentId)
+            .orElseThrow(() -> new BusinessException(PostErrorCode.COMMENT_NOT_FOUND));
+
+        Post post = postRepository.findById(comment.getPostId())
+            .orElseThrow(() -> new BusinessException(PostErrorCode.POST_NOT_FOUND));
+
+        post.decrementCommentCount();
+        postRepository.save(post);
+
+        commentRepository.delete(comment);
+    }
+
+    @Transactional
+    public void deleteCaseRequest(Long caseRequestId) {
+        CaseRequest caseRequest = caseRequestRepository.findById(caseRequestId)
+            .orElseThrow(() -> new BusinessException(CaseErrorCode.CASE_REQUEST_NOT_FOUND));
+
+        caseRequestRepository.delete(caseRequest);
+    }
+
+
+    @Transactional(readOnly = true)
+    public AdminDashboardResponseDTO getDashboardStats() {
+        long totalUsers = userRepository.count();
+        long totalPosts = postRepository.count();
+        long totalCaseRequests = caseRequestRepository.count();
+        long pendingReports = reportRepository.countByStatus(ReportStatus.PENDING);
+        long acceptedReports = reportRepository.countByStatus(ReportStatus.ACCEPTED);
+        long rejectedReports = reportRepository.countByStatus(ReportStatus.REJECTED);
+
+        return AdminDashboardResponseDTO.of(
+            totalUsers, totalPosts, totalCaseRequests,
+            pendingReports, acceptedReports, rejectedReports
+        );
+    }
+
+
+    private Report findReportOrThrow(Long reportId) {
+        return reportRepository.findById(reportId)
+            .orElseThrow(() -> new BusinessException(ReportErrorCode.REPORT_NOT_FOUND));
+    }
+
+    private User findUserOrThrow(Long userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
# 변경사항
- 관리자 권한을 가진 사용자가 플랫폼을 관리할 수 있는 관리자 기능을 구현했습니다.
- 접수된 신고를 처리하고, 사용자 계정을 정지/복원하며, 부적절한 콘텐츠를 강제 삭제하고, 플랫폼 전체 통계를 조회할 수 있습니다.
- 모든 관리자 API 는 ADMIN 권한이 있는 사용자만 접근 가능합니다.

## 설계 고려 방향
### 1. 계정 정지 구현 방식 - 엔티티 필드 vs 별도 테이블
- user 엔티티에 필드 추가하면 조회 시 join이 불필요하고, 구현 단순해지지만 user entity가 비대화 
- 별도 테이블 형성 시 정지 이력 관리 가능 하지만 매 요청마다 join 필요

이 방향에서 저는 user엔티티에 필드를 추가하는 방식을 선택했습니다. 
- 로그인 시 매 요청마다 정지 여부를 체크해야 하므로 join 없이 단일 테이블에서 확인하는 것이 성능상 유리 할 것이라 생각이 들었고
- spring security에서 user.isSusponede()를 호출할 수 있기 때문입니다.
- 추후에 정지 이력이 필요한 경우 별도 테이블로 분리 할 생각도 있습니다.

