### PR TITLE
fix: globalExceptionHandler 응답 통일

### DIFF
--- a/prothsync/src/main/java/com/prothsync/prothsync/exception/GlobalExceptionHandler.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/exception/GlobalExceptionHandler.java
@@ -33,7 +33,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    protected ResponseEntity<String> handleMethodArgumentNotValidException(
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
         MethodArgumentNotValidException e) {
         log.warn("handleMethodArgumentNotValidException : {}", e.getMessage());
 
@@ -43,11 +43,11 @@ public class GlobalExceptionHandler {
             .orElse(WRONG_REQUEST);
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-            .body(errorMessage);
+            .body(ErrorResponse.of("VALIDATION_ERROR", errorMessage));
     }
 
     @ExceptionHandler(BindException.class)
-    protected ResponseEntity<String> handleBindException(BindException e) {
+    protected ResponseEntity<ErrorResponse> handleBindException(BindException e) {
         log.warn("handleBindException : {}", e.getMessage());
 
         String errorMessage = e.getBindingResult().getFieldErrors().stream()
@@ -56,7 +56,7 @@ public class GlobalExceptionHandler {
             .orElse(WRONG_REQUEST);
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-            .body(errorMessage);
+            .body(ErrorResponse.of("VALIDATION_ERROR", errorMessage));
     }
 
     @ExceptionHandler({
@@ -66,42 +66,42 @@ public class GlobalExceptionHandler {
         MethodArgumentTypeMismatchException.class,
         HttpMessageNotReadableException.class
     })
-    protected ResponseEntity<String> handleValidException(Exception e) {
+    protected ResponseEntity<ErrorResponse> handleValidException(Exception e) {
         log.warn("handleValidException : {}", e.getMessage());
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-            .body(WRONG_REQUEST);
+            .body(ErrorResponse.of("BAD_REQUEST", WRONG_REQUEST));
     }
 
     @ExceptionHandler({
         NoHandlerFoundException.class,
         NoResourceFoundException.class
     })
-    protected ResponseEntity<String> handleNotFoundException(Exception e) {
+    protected ResponseEntity<ErrorResponse> handleNotFoundException(Exception e) {
         log.warn("handleNotFoundException : {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
-            .body("요청하신 리소스를 찾을 수 없습니다.");
+            .body(ErrorResponse.of("NOT_FOUND", "요청하신 리소스를 찾을 수 없습니다."));
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
-    protected ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException e) {
+    protected ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
         log.warn("handleIllegalArgumentException : {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-            .body(e.getMessage());
+            .body(ErrorResponse.of("BAD_REQUEST", e.getMessage()));
     }
 
     @ExceptionHandler(AuthorizationDeniedException.class)
-    protected ResponseEntity<String> handleAuthorizationDeniedException(
+    protected ResponseEntity<ErrorResponse> handleAuthorizationDeniedException(
         AuthorizationDeniedException e) {
         log.warn("handleAuthorizationDeniedException : {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.FORBIDDEN)
-            .body(e.getMessage());
+            .body(ErrorResponse.of("ACCESS_DENIED", "접근 권한이 없습니다."));
     }
 
     @ExceptionHandler(Exception.class)
-    protected ResponseEntity<String> handleException(Exception e) {
+    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
         log.error("handleException : {}", e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-            .body("서버 내부 오류가 발생했습니다.");
+            .body(ErrorResponse.of("INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다."));
     }
 }


### PR DESCRIPTION
# 수정사항
- GlobalExceptionHandler의 모든 예외 핸들러가 동일한 ErrorResponse 형식으로 응답하도록 통일했습니다. 

## 변경 배경
- 기존에는 BusinessExcepotion만 ErrorResponse JSON 객체로 응답하고, 나머지 핸들러는 String으로 응답하고 있었습니다.
- 그래서 이로 인해 클라이언트에서 에러 응답을 할때 일관되지 않아 프론트엔드 에러 핸들링의 복잡도를 높일 거라 생각을 하고 통일 작업을 시작하였습니다.

### Before
```
HTTP 400
Content-Type: text/plain

닉네임은 필수입니다
```

### After
```
HTTP 400
Content-Type: application/json

{
  "errorName": "VALIDATION_ERROR",
  "message": "닉네임은 필수입니다"
}
```