### PR TITLE
fix: hard delete -> soft delete로 변경

### DIFF
--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/AdminController.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/AdminController.java
@@ -100,25 +100,28 @@ public class AdminController implements AdminControllerDocs {
 
     @DeleteMapping("/posts/{postId}")
     public ResponseEntity<Void> deletePost(
-        @PathVariable Long postId
+        @PathVariable Long postId,
+        @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        adminService.deletePost(postId);
+        adminService.deletePost(postId, userDetails.getUserId());
         return ResponseEntity.noContent().build();
     }
 
     @DeleteMapping("/comments/{commentId}")
     public ResponseEntity<Void> deleteComment(
-        @PathVariable Long commentId
+        @PathVariable Long commentId,
+        @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        adminService.deleteComment(commentId);
+        adminService.deleteComment(commentId, userDetails.getUserId());
         return ResponseEntity.noContent().build();
     }
 
     @DeleteMapping("/cases/{caseRequestId}")
     public ResponseEntity<Void> deleteCaseRequest(
-        @PathVariable Long caseRequestId
+        @PathVariable Long caseRequestId,
+        @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        adminService.deleteCaseRequest(caseRequestId);
+        adminService.deleteCaseRequest(caseRequestId, userDetails.getUserId());
         return ResponseEntity.noContent().build();
     }
 

--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/AdminControllerDocs.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/AdminControllerDocs.java
@@ -108,29 +108,38 @@ public interface AdminControllerDocs {
     );
 
 
-    @Operation(summary = "게시글 강제 삭제", description = "관리자 권한으로 게시글을 삭제합니다. 관련 좋아요, 북마크, 댓글, 해시태그, 이미지가 함께 삭제됩니다.")
+    @Operation(summary = "게시글 강제 삭제", description = "관리자 권한으로 게시글을 soft delete 합니다. 관련 좋아요, 북마크는 hard delete, 댓글/이미지는 soft delete 됩니다.")
     @ApiResponses({
         @ApiResponse(responseCode = "204", description = "삭제 성공"),
         @ApiResponse(responseCode = "404", description = "게시글을 찾을 수 없음",
             content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    ResponseEntity<Void> deletePost(@Parameter(description = "게시글 ID") Long postId);
+    ResponseEntity<Void> deletePost(
+        @Parameter(description = "게시글 ID") Long postId,
+        CustomUserDetails userDetails
+    );
 
-    @Operation(summary = "댓글 강제 삭제", description = "관리자 권한으로 댓글을 삭제합니다. 게시글의 댓글 수가 자동으로 감소합니다.")
+    @Operation(summary = "댓글 강제 삭제", description = "관리자 권한으로 댓글을 soft delete 합니다. 게시글의 댓글 수가 자동으로 감소합니다.")
     @ApiResponses({
         @ApiResponse(responseCode = "204", description = "삭제 성공"),
         @ApiResponse(responseCode = "404", description = "댓글을 찾을 수 없음",
             content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    ResponseEntity<Void> deleteComment(@Parameter(description = "댓글 ID") Long commentId);
+    ResponseEntity<Void> deleteComment(
+        @Parameter(description = "댓글 ID") Long commentId,
+        CustomUserDetails userDetails
+    );
 
-    @Operation(summary = "의뢰 강제 삭제", description = "관리자 권한으로 의뢰를 삭제합니다.")
+    @Operation(summary = "의뢰 강제 삭제", description = "관리자 권한으로 의뢰를 soft delete 합니다.")
     @ApiResponses({
         @ApiResponse(responseCode = "204", description = "삭제 성공"),
         @ApiResponse(responseCode = "404", description = "의뢰를 찾을 수 없음",
             content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    ResponseEntity<Void> deleteCaseRequest(@Parameter(description = "의뢰 ID") Long caseRequestId);
+    ResponseEntity<Void> deleteCaseRequest(
+        @Parameter(description = "의뢰 ID") Long caseRequestId,
+        CustomUserDetails userDetails
+    );
 
 
     @Operation(summary = "대시보드 통계 조회", description = "총 사용자 수, 게시글 수, 의뢰 수, 신고 현황 등 플랫폼 전체 통계를 조회합니다.")

--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/caserequest/CaseProposal.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/caserequest/CaseProposal.java
@@ -14,9 +14,11 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "case_proposals")
+@SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CaseProposal extends BaseEntity {

--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/caserequest/CaseRequest.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/caserequest/CaseRequest.java
@@ -15,9 +15,11 @@ import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "case_requests")
+@SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CaseRequest extends BaseEntity {

--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/notification/Notification.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/notification/Notification.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(
@@ -21,6 +22,7 @@ import lombok.NoArgsConstructor;
         @Index(name = "idx_notification_recipient", columnList = "recipient_id, is_read, created_at")
     }
 )
+@SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Notification extends BaseEntity {

--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/post/Comment.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/post/Comment.java
@@ -12,9 +12,11 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "comments" )
+@SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Comment extends BaseEntity {

--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/post/Post.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/post/Post.java
@@ -14,9 +14,11 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "posts")
+@SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post extends BaseEntity {

--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/post/PostImage.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/post/PostImage.java
@@ -12,9 +12,11 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "post_images")
+@SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PostImage extends BaseEntity {

--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/report/Report.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/report/Report.java
@@ -16,6 +16,7 @@ import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(
@@ -27,6 +28,7 @@ import lombok.NoArgsConstructor;
         )
     }
 )
+@SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Report extends BaseEntity {

--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/review/Review.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/review/Review.java
@@ -7,6 +7,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(
@@ -18,6 +19,7 @@ import lombok.NoArgsConstructor;
         )
     }
 )
+@SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Review extends BaseEntity {

--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/user/User.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/user/User.java
@@ -17,9 +17,11 @@ import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name="users")
+@SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/CaseProposalRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/CaseProposalRepositoryImpl.java
@@ -28,8 +28,9 @@ public class CaseProposalRepositoryImpl implements CaseProposalRepository {
     }
 
     @Override
-    public void delete(CaseProposal proposal) {
-        caseProposalJpaRepository.delete(proposal);
+    public void softDelete(CaseProposal proposal, Long userId) {
+        proposal.delete(userId);
+        caseProposalJpaRepository.save(proposal);
     }
 
     @Override
@@ -58,7 +59,7 @@ public class CaseProposalRepositoryImpl implements CaseProposalRepository {
     }
 
     @Override
-    public void deleteAllByCaseRequestId(Long caseRequestId) {
-        caseProposalJpaRepository.deleteAllByCaseRequestId(caseRequestId);
+    public void softDeleteAllByCaseRequestId(Long caseRequestId, Long userId) {
+        caseProposalJpaRepository.softDeleteAllByCaseRequestId(caseRequestId, userId);
     }
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/CaseRequestRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/CaseRequestRepositoryImpl.java
@@ -29,8 +29,9 @@ public class CaseRequestRepositoryImpl implements CaseRequestRepository {
     }
 
     @Override
-    public void delete(CaseRequest caseRequest) {
-        caseRequestJpaRepository.delete(caseRequest);
+    public void softDelete(CaseRequest caseRequest, Long userId) {
+        caseRequest.delete(userId);
+        caseRequestJpaRepository.save(caseRequest);
     }
 
     @Override

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/CommentRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/CommentRepositoryImpl.java
@@ -31,13 +31,14 @@ public class CommentRepositoryImpl implements CommentRepository {
     }
 
     @Override
-    public void delete(Comment comment) {
-        commentJpaRepository.delete(comment);
+    public void softDelete(Comment comment, Long userId) {
+        comment.delete(userId);
+        commentJpaRepository.save(comment);
     }
 
     @Override
-    public void deleteAllByPostId(Long postId) {
-        commentJpaRepository.deleteAllByPostId(postId);
+    public void softDeleteAllByPostId(Long postId, Long userId) {
+        commentJpaRepository.softDeleteAllByPostId(postId, userId);
     }
 
     @Override

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/NotificationRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/NotificationRepositoryImpl.java
@@ -27,13 +27,13 @@ public class NotificationRepositoryImpl implements NotificationRepository {
 
     @Override
     public Page<Notification> findByRecipientId(Long recipientId, Pageable pageable) {
-        return notificationJpaRepository.findByRecipientIdAndDeletedAtIsNullOrderByCreatedAtDesc(
+        return notificationJpaRepository.findByRecipientIdOrderByCreatedAtDesc(
             recipientId, pageable);
     }
 
     @Override
     public int countUnreadByRecipientId(Long recipientId) {
-        return notificationJpaRepository.countByRecipientIdAndIsReadFalseAndDeletedAtIsNull(recipientId);
+        return notificationJpaRepository.countByRecipientIdAndIsReadFalse(recipientId);
     }
 
     @Override

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/PostImageRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/PostImageRepositoryImpl.java
@@ -45,8 +45,8 @@ public class PostImageRepositoryImpl implements PostImageRepository {
     }
 
     @Override
-    public void deleteAllByPostId(Long postId) {
-        postImageJpaRepository.deleteAllByPostId(postId);
+    public void softDeleteAllByPostId(Long postId, Long userId) {
+        postImageJpaRepository.softDeleteAllByPostId(postId, userId);
     }
 
     @Override

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/PostRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/PostRepositoryImpl.java
@@ -29,8 +29,9 @@ public class PostRepositoryImpl implements PostRepository {
     }
 
     @Override
-    public void delete(Post post) {
-        postJpaRepository.delete(post);
+    public void softDelete(Post post, Long userId) {
+        post.delete(userId);
+        postJpaRepository.save(post);
     }
 
     @Override

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/ReviewRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/ReviewRepositoryImpl.java
@@ -26,8 +26,9 @@ public class ReviewRepositoryImpl implements ReviewRepository {
     }
 
     @Override
-    public void delete(Review review) {
-        reviewJpaRepository.delete(review);
+    public void softDelete(Review review, Long userId) {
+        review.delete(userId);
+        reviewJpaRepository.save(review);
     }
 
     @Override

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/CaseProposalJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/CaseProposalJpaRepository.java
@@ -6,6 +6,9 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CaseProposalJpaRepository extends JpaRepository<CaseProposal, Long> {
 
@@ -19,5 +22,7 @@ public interface CaseProposalJpaRepository extends JpaRepository<CaseProposal, L
 
     long countByCaseRequestId(Long caseRequestId);
 
-    void deleteAllByCaseRequestId(Long caseRequestId);
+    @Modifying
+    @Query("UPDATE CaseProposal cp SET cp.deletedAt = CURRENT_TIMESTAMP, cp.deletedBy = :userId WHERE cp.caseRequestId = :caseRequestId AND cp.deletedAt IS NULL")
+    int softDeleteAllByCaseRequestId(@Param("caseRequestId") Long caseRequestId, @Param("userId") Long userId);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/CaseRequestJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/CaseRequestJpaRepository.java
@@ -29,6 +29,7 @@ public interface CaseRequestJpaRepository extends JpaRepository<CaseRequest, Lon
           AND cr.longitude IS NOT NULL
           AND cr.client_id != :excludeUserId
           AND cr.status = 'OPEN'
+          AND cr.deleted_at IS NULL
           AND (
             6371 * acos(
               LEAST(1.0, GREATEST(-1.0,
@@ -67,6 +68,7 @@ public interface CaseRequestJpaRepository extends JpaRepository<CaseRequest, Lon
           AND cr.client_id != :excludeUserId
           AND cr.status = 'OPEN'
           AND cr.category = :category
+          AND cr.deleted_at IS NULL
           AND (
             6371 * acos(
               LEAST(1.0, GREATEST(-1.0,

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/CommentJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/CommentJpaRepository.java
@@ -4,12 +4,17 @@ import com.prothsync.prothsync.entity.post.Comment;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CommentJpaRepository extends JpaRepository<Comment, Long> {
 
     Page<Comment> findAllByPostId(Long postId, Pageable pageable);
 
-    void deleteAllByPostId(Long postId);
-
     int countByPostId(Long postId);
+
+    @Modifying
+    @Query("UPDATE Comment c SET c.deletedAt = CURRENT_TIMESTAMP, c.deletedBy = :userId WHERE c.postId = :postId AND c.deletedAt IS NULL")
+    int softDeleteAllByPostId(@Param("postId") Long postId, @Param("userId") Long userId);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/NotificationJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/NotificationJpaRepository.java
@@ -10,10 +10,10 @@ import org.springframework.data.repository.query.Param;
 
 public interface NotificationJpaRepository extends JpaRepository<Notification, Long> {
 
-    Page<Notification> findByRecipientIdAndDeletedAtIsNullOrderByCreatedAtDesc(
+    Page<Notification> findByRecipientIdOrderByCreatedAtDesc(
         Long recipientId, Pageable pageable);
 
-    int countByRecipientIdAndIsReadFalseAndDeletedAtIsNull(Long recipientId);
+    int countByRecipientIdAndIsReadFalse(Long recipientId);
 
     @Modifying
     @Query("UPDATE Notification n SET n.isRead = true WHERE n.recipientId = :recipientId AND n.isRead = false AND n.deletedAt IS NULL")

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/PostImageJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/PostImageJpaRepository.java
@@ -3,6 +3,9 @@ package com.prothsync.prothsync.repository.jpa;
 import com.prothsync.prothsync.entity.post.PostImage;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PostImageJpaRepository extends JpaRepository<PostImage, Long> {
 
@@ -10,7 +13,9 @@ public interface PostImageJpaRepository extends JpaRepository<PostImage, Long> {
 
     List<PostImage> findAllByPostIdOrderByDisplayOrderAsc(Long postId);
 
-    void deleteAllByPostId(Long postId);
-
     int countByPostId(Long postId);
+
+    @Modifying
+    @Query("UPDATE PostImage pi SET pi.deletedAt = CURRENT_TIMESTAMP, pi.deletedBy = :userId WHERE pi.postId = :postId AND pi.deletedAt IS NULL")
+    int softDeleteAllByPostId(@Param("postId") Long postId, @Param("userId") Long userId);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/UserJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/UserJpaRepository.java
@@ -33,6 +33,7 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
           AND u.longitude IS NOT NULL
           AND u.user_id != :excludeUserId
           AND u.user_type IN (:searchableTypes)
+          AND u.deleted_at IS NULL
           AND (
             6371 * acos(
               LEAST(1.0, GREATEST(-1.0,
@@ -72,6 +73,7 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
           AND u.longitude IS NOT NULL
           AND u.user_id != :excludeUserId
           AND u.user_type = :userType
+          AND u.deleted_at IS NULL
           AND (
             6371 * acos(
               LEAST(1.0, GREATEST(-1.0,

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/CaseProposalRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/CaseProposalRepository.java
@@ -13,7 +13,7 @@ public interface CaseProposalRepository {
 
     Optional<CaseProposal> findById(Long proposalId);
 
-    void delete(CaseProposal proposal);
+    void softDelete(CaseProposal proposal, Long userId);
 
     Page<CaseProposal> findAllByCaseRequestId(Long caseRequestId, Pageable pageable);
 
@@ -25,5 +25,5 @@ public interface CaseProposalRepository {
 
     long countByCaseRequestId(Long caseRequestId);
 
-    void deleteAllByCaseRequestId(Long caseRequestId);
+    void softDeleteAllByCaseRequestId(Long caseRequestId, Long userId);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/CaseRequestRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/CaseRequestRepository.java
@@ -14,7 +14,7 @@ public interface CaseRequestRepository {
 
     Optional<CaseRequest> findById(Long caseRequestId);
 
-    void delete(CaseRequest caseRequest);
+    void softDelete(CaseRequest caseRequest, Long userId);
 
     Page<CaseRequest> findAllByStatus(CaseStatus status, Pageable pageable);
 

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/CommentRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/CommentRepository.java
@@ -13,9 +13,9 @@ public interface CommentRepository {
 
     Page<Comment> findAllByPostId(Long postId, Pageable pageable);
 
-    void delete(Comment comment);
+    void softDelete(Comment comment, Long userId);
 
-    void deleteAllByPostId(Long postId);
+    void softDeleteAllByPostId(Long postId, Long userId);
 
     int countByPostId(Long postId);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/PostImageRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/PostImageRepository.java
@@ -18,7 +18,7 @@ public interface PostImageRepository {
 
     void delete(PostImage postImage);
 
-    void deleteAllByPostId(Long postId);
+    void softDeleteAllByPostId(Long postId, Long userId);
 
     int countByPostId(Long postId);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/PostRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/PostRepository.java
@@ -11,7 +11,7 @@ public interface PostRepository {
 
     Post save(Post post);
     Optional<Post> findById(Long postId);
-    void delete(Post post);
+    void softDelete(Post post, Long userId);
     Page<Post> findAllByVisibilityPublic(Pageable pageable);
 
     Page<Post> findAllByUserId(Long userId, Pageable pageable);

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/ReviewRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/ReviewRepository.java
@@ -11,7 +11,7 @@ public interface ReviewRepository {
 
     Optional<Review> findById(Long reviewId);
 
-    void delete(Review review);
+    void softDelete(Review review, Long userId);
 
     boolean existsByCaseRequestId(Long caseRequestId);
 

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/AdminService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/AdminService.java
@@ -148,20 +148,20 @@ public class AdminService {
 
 
     @Transactional
-    public void deletePost(Long postId) {
+    public void deletePost(Long postId, Long adminUserId) {
         Post post = postRepository.findById(postId)
             .orElseThrow(() -> new BusinessException(PostErrorCode.POST_NOT_FOUND));
 
         postLikeRepository.deleteAllByPostId(postId);
         bookmarkRepository.deleteAllByPostId(postId);
-        commentService.deleteAllByPostId(postId);
+        commentService.softDeleteAllByPostId(postId, adminUserId);
         hashtagService.removeAllHashtagsFromPost(postId);
-        postImageService.deleteAllByPostId(postId);
-        postRepository.delete(post);
+        postImageService.softDeleteAllByPostId(postId, adminUserId);
+        postRepository.softDelete(post, adminUserId);
     }
 
     @Transactional
-    public void deleteComment(Long commentId) {
+    public void deleteComment(Long commentId, Long adminUserId) {
         Comment comment = commentRepository.findById(commentId)
             .orElseThrow(() -> new BusinessException(PostErrorCode.COMMENT_NOT_FOUND));
 
@@ -171,15 +171,15 @@ public class AdminService {
         post.decrementCommentCount();
         postRepository.save(post);
 
-        commentRepository.delete(comment);
+        commentRepository.softDelete(comment, adminUserId);
     }
 
     @Transactional
-    public void deleteCaseRequest(Long caseRequestId) {
+    public void deleteCaseRequest(Long caseRequestId, Long adminUserId) {
         CaseRequest caseRequest = caseRequestRepository.findById(caseRequestId)
             .orElseThrow(() -> new BusinessException(CaseErrorCode.CASE_REQUEST_NOT_FOUND));
 
-        caseRequestRepository.delete(caseRequest);
+        caseRequestRepository.softDelete(caseRequest, adminUserId);
     }
 
 

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/CaseProposalService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/CaseProposalService.java
@@ -130,7 +130,7 @@ public class CaseProposalService {
         caseRequest.decrementProposalCount();
         caseRequestRepository.save(caseRequest);
 
-        caseProposalRepository.delete(proposal);
+        caseProposalRepository.softDelete(proposal, userId);
     }
 
     @Transactional

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/CaseRequestService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/CaseRequestService.java
@@ -127,8 +127,8 @@ public class CaseRequestService {
         CaseRequest caseRequest = findCaseRequestOrThrow(caseRequestId);
         validateOwner(caseRequest, userId);
 
-        caseProposalRepository.deleteAllByCaseRequestId(caseRequestId);
-        caseRequestRepository.delete(caseRequest);
+        caseProposalRepository.softDeleteAllByCaseRequestId(caseRequestId, userId);
+        caseRequestRepository.softDelete(caseRequest, userId);
     }
 
     @Transactional(readOnly = true)

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/CommentService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/CommentService.java
@@ -80,12 +80,12 @@ public class CommentService {
         post.decrementCommentCount();
         postRepository.save(post);
 
-        commentRepository.delete(comment);
+        commentRepository.softDelete(comment, userId);
     }
 
     @Transactional
-    public void deleteAllByPostId(Long postId) {
-        commentRepository.deleteAllByPostId(postId);
+    public void softDeleteAllByPostId(Long postId, Long userId) {
+        commentRepository.softDeleteAllByPostId(postId, userId);
     }
 
     private Post findPostOrThrow(Long postId) {

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/PostImageService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/PostImageService.java
@@ -40,8 +40,8 @@ public class PostImageService {
     }
 
     @Transactional
-    public List<PostImage> replaceImages(Long postId, List<String> imageUrls) {
-        deleteAllByPostId(postId);
+    public List<PostImage> replaceImages(Long postId, Long userId, List<String> imageUrls) {
+        softDeleteAllByPostId(postId, userId);
         return saveImages(postId, imageUrls);
     }
 
@@ -59,9 +59,9 @@ public class PostImageService {
     }
 
     @Transactional
-    public void deleteAllByPostId(Long postId) {
+    public void softDeleteAllByPostId(Long postId, Long userId) {
         // TODO: S3 도입 시 실제 파일 삭제 처리 추가
-        postImageRepository.deleteAllByPostId(postId);
+        postImageRepository.softDeleteAllByPostId(postId, userId);
     }
 
     private void validateImageCount(List<String> imageUrls) {

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/PostService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/PostService.java
@@ -110,7 +110,7 @@ public class PostService {
         postRepository.save(post);
 
         if (request.imageUrls() != null) {
-            postImageService.replaceImages(postId, request.imageUrls());
+            postImageService.replaceImages(postId, userId, request.imageUrls());
         }
         if (request.hashtagNames() != null) {
             hashtagService.replaceHashtagsForPost(postId, request.hashtagNames());
@@ -126,10 +126,10 @@ public class PostService {
 
         postLikeRepository.deleteAllByPostId(postId);
         bookmarkRepository.deleteAllByPostId(postId);
-        commentService.deleteAllByPostId(postId);
+        commentService.softDeleteAllByPostId(postId, userId);
         hashtagService.removeAllHashtagsFromPost(postId);
-        postImageService.deleteAllByPostId(postId);
-        postRepository.delete(post);
+        postImageService.softDeleteAllByPostId(postId, userId);
+        postRepository.softDelete(post, userId);
     }
 
 

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/ReviewService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/ReviewService.java
@@ -137,7 +137,7 @@ public class ReviewService {
 
         Long revieweeId = review.getRevieweeId();
 
-        reviewRepository.delete(review);
+        reviewRepository.softDelete(review, userId);
 
         // 삭제 후 대상자의 평균 평점 갱신
         updateUserRatingStats(revieweeId);


### PR DESCRIPTION
# 변경사항
- BaseEntity에 이미 구현되어 있지만 활용되지 않던 deletedAt/deledBy 필드를 사용하고자 바꾸는 작업이였습니다.
- 기존에는 JPA delete()를 호출하여 데이터베이스에서 hard delete를 하고 있었습니다.
- 이 변경으로 hard delete -> soft delte로 변경하였습니다.
### 중요한 것은 그렇다고 해서 모든 것을 soft delete를 바꾼 것은 아닙니다.

## Soft Delete 하는 것
- User
-  Post
- PostImage
- Comment
- CaseRequest
- CaseProposal
- Review
- Report
- Notification

## Hard Delete 
- PostLike
- Bookmark
- Follow
- Block
- PostHashtag
- Hashtag
-  위에 엔티티들을 모두 uniqueConstraint를 가지고 있어 soft delete를 레코드가 있으면 오류가 발생하기 때문에 hard delete를 유지했습니다.

## 구현 내용
### Entity에 @SQLRestriction 추가
- @SQLRestriction("deleted_at IS NULL")을 soft delete 엔티티 9개에 추가했습니다. 이 어노테이션 하나로 해당 엔티티의 모든 Spring Data JPA 파생 쿼리(findBy*)와 JPQL 쿼리에 자동으로 WHERE deleted_at IS NULL 조건이 붙습니다.
