### PR TITLE
fix: blockedIds 활용

### DIFF
--- a/prothsync/src/main/java/com/prothsync/prothsync/service/FeedService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/FeedService.java
@@ -10,7 +10,9 @@ import com.prothsync.prothsync.repository.repository.BookmarkRepository;
 import com.prothsync.prothsync.repository.repository.FollowRepository;
 import com.prothsync.prothsync.repository.repository.PostLikeRepository;
 import com.prothsync.prothsync.repository.repository.PostRepository;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -37,9 +39,17 @@ public class FeedService {
             return PageResponse.empty();
         }
 
-        Page<Post> postPage = postRepository.findFeedPostsByUserIds(followingIds, pageable);
+        Set<Long> blockedIdSet = new HashSet<>(blockRepository.findBlockedIdsByBlockerId(userId));
+        List<Long> filteredFollowingIds = followingIds.stream()
+            .filter(id -> !blockedIdSet.contains(id))
+            .toList();
 
-        List<Long> blockedIds = blockRepository.findBlockedIdsByBlockerId(userId);
+        if (filteredFollowingIds.isEmpty()) {
+            return PageResponse.empty();
+        }
+
+        Page<Post> postPage = postRepository.findFeedPostsByUserIds(filteredFollowingIds, pageable);
+
         List<PostResponseDTO> feedPosts = postPage.getContent().stream()
             .map(post -> buildPostResponseDTO(post, userId))
             .toList();


### PR DESCRIPTION
# 수정사항
FeedService에서 getFollowingFeed()에서 차단된 사용자 ID 목록을 조회하고 있지만. 실제로 List를 활용하는 로직이 없었습니다.
```
List<Long> blockedIds = blockRepository.findBlockedIdsByBlockerId(userId);
List<PostResponseDTO> feedPosts = postPage.getContent().stream()
    .map(post -> buildPostResponseDTO(post, userId))
    .toList();
```
### 그 결과 사용자가 특정 유저를 차단하더라도 해당 유저의 게시물이 팔로잉 피드에 그대로 노출되는 문제가 있었습니다.

- 그래서 차단된 사용자 Id를 followingIds 에서 사전에 제거하여, DB 쿼리 시점부터 차단 유저의 게시물을 배제하도록 수정했습니다.

### 이 때 차단된 사용자 ID 목록을 List와 HashSet 중 어떤 것을 사용할지 고민했습니다.
- 그런데 List는 시간 복잡도는 팔로잉 목록(m)명 과 차단 목록(n)명을 탐색하면 O(m*n) 이 걸리고
- HashSet은 해시 기분으로 O(m) 정도만 걸리기 때문에 HashSet을 이용하였습니다.