### PR TITLE
fix: 팔로워,팔로잉 목록 조회 시 N+1 문제 발생 문제 해결

### DIFF
--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/UserRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/UserRepositoryImpl.java
@@ -71,6 +71,11 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
+    public List<User> findAllByIds(List<Long> userIds) {
+        return userJpaRepository.findAllByUserIdIn(userIds);
+    }
+
+    @Override
     public Page<User> searchByNickName(String keyword, Pageable pageable) {
         return userJpaRepository.findByNickNameContainingIgnoreCase(keyword, pageable);
     }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/UserJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/UserJpaRepository.java
@@ -103,6 +103,8 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
         @Param("limit") int limit
     );
 
+    List<User> findAllByUserIdIn(List<Long> userIds);
+
     Page<User> findByNickNameContainingIgnoreCase(String keyword, Pageable pageable);
 
     Page<User> findAll(Pageable pageable);

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/UserRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/UserRepository.java
@@ -22,6 +22,8 @@ public interface UserRepository {
     List<User> findNearbyUsersByType(double lat, double lng, double radiusKm,
         Long excludeUserId, String userType, int limit);
 
+    List<User> findAllByIds(List<Long> userIds);
+
     Page<User> searchByNickName(String keyword, Pageable pageable);
 
     Page<User> findAll(Pageable pageable);

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/FollowService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/FollowService.java
@@ -12,7 +12,10 @@ import com.prothsync.prothsync.global.PageResponse;
 import com.prothsync.prothsync.repository.repository.FollowRepository;
 import com.prothsync.prothsync.repository.repository.UserRepository;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -71,9 +74,21 @@ public class FollowService {
 
         Page<Follow> followPage = followRepository.findAllByFollowingId(userId, pageable);
 
-        List<FollowUserResponseDTO> followers = followPage.getContent().stream()
-            .map(follow -> findUserOrThrow(follow.getFollowerId()))
-            .map(FollowUserResponseDTO::from)
+        List<Long> followerIds = followPage.getContent().stream()
+            .map(Follow::getFollowerId)
+            .toList();
+
+        Map<Long, User> userMap = userRepository.findAllByIds(followerIds).stream()
+            .collect(Collectors.toMap(User::getUserId, Function.identity()));
+
+        List<FollowUserResponseDTO> followers = followerIds.stream()
+            .map(id -> {
+                User user = userMap.get(id);
+                if (user == null) {
+                    throw new BusinessException(UserErrorCode.USER_NOT_FOUND);
+                }
+                return FollowUserResponseDTO.from(user);
+            })
             .toList();
 
         return PageResponse.of(followers, followPage);
@@ -85,9 +100,21 @@ public class FollowService {
 
         Page<Follow> followPage = followRepository.findAllByFollowerId(userId, pageable);
 
-        List<FollowUserResponseDTO> followings = followPage.getContent().stream()
-            .map(follow -> findUserOrThrow(follow.getFollowingId()))
-            .map(FollowUserResponseDTO::from)
+        List<Long> followingIds = followPage.getContent().stream()
+            .map(Follow::getFollowingId)
+            .toList();
+
+        Map<Long, User> userMap = userRepository.findAllByIds(followingIds).stream()
+            .collect(Collectors.toMap(User::getUserId, Function.identity()));
+
+        List<FollowUserResponseDTO> followings = followingIds.stream()
+            .map(id -> {
+                User user = userMap.get(id);
+                if (user == null) {
+                    throw new BusinessException(UserErrorCode.USER_NOT_FOUND);
+                }
+                return FollowUserResponseDTO.from(user);
+            })
             .toList();
 
         return PageResponse.of(followings, followPage);


### PR DESCRIPTION
# 수정사항
- FollowService에서 팔로잉, 팔로워 목록을 불러오는 메서드에서 N+1 문제가 발생하였습니다.
- 기존에는 Follow 목록을 조회한 후 각 Follow의 User를 1건씩 개별 조회하여 이 유저가 실제로 존재하는지 체크를 했습니다.
- 이 작업으로 인해 팔로워 혹은 팔로우가 N명 일경우 N+1개의 쿼리가 발생하였습니다.
- 이를 IN 쿼리 배치 조회로 변경하여 항상 2개의 쿼리로 처리되도록 개선했습니다.

# 변경 후 좋은 점
- 자체 테스트 파일로 테스트 결과 실행시간 50% 이상 단축 100명 이상 팔로우 존재 시 쿼리문 98%이상 단축 효과를 보였습니다.
