### PR TITLE
fix: SearchService 해시태그 검색 썸네일 조회 N+1 문제 해결

### DIFF
--- a/prothsync/src/main/java/com/prothsync/prothsync/service/SearchService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/SearchService.java
@@ -15,6 +15,7 @@ import com.prothsync.prothsync.repository.repository.HashtagRepository;
 import com.prothsync.prothsync.repository.repository.PostRepository;
 import com.prothsync.prothsync.repository.repository.UserRepository;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -62,10 +63,19 @@ public class SearchService {
 
         List<Long> blockedIds = getBlockedIds(currentUserId);
 
-        List<PostSummaryResponseDTO> summaries = postPage.getContent().stream()
+        List<Post> filteredPosts = postPage.getContent().stream()
             .filter(post -> !blockedIds.contains(post.getUserId()))
+            .toList();
+
+        List<Long> postIds = filteredPosts.stream()
+            .map(Post::getPostId)
+            .toList();
+
+        Map<Long, String> thumbnailMap = postImageService.getThumbnailUrls(postIds);
+
+        List<PostSummaryResponseDTO> summaries = filteredPosts.stream()
             .map(post -> PostSummaryResponseDTO.of(
-                post, postImageService.getThumbnailUrl(post.getPostId())))
+                post, thumbnailMap.get(post.getPostId())))
             .toList();
 
         return PageResponse.of(summaries, postPage);


### PR DESCRIPTION
# 수정사항
- SearchService.searchPostsByHashtag()에서 게시물 목록을 PostSummaryResponseDTO로 변환할 때, 각 게시물마다 PostImageService.getThumbnailUrl(postId)를 개별 호출하면서 N+1 쿼리 문제가 발생하고 있었습니다.

- 이전 PostService PR에서 추가한 PostImageService.getThumbnailUrls(List<Long>) 배치 메서드를 재사용하여 해결합니다.

# 변경사항
- 썸네일 쿼리 수  => 전에는 N 번 / 수정 후 1번
- 총 쿼리 수  => 3+ N번 / 수정 후 4회 (고정)