### PR TITLE
fix: hashtag N+1 문제 해결

### DIFF
--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/HashtagRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/HashtagRepositoryImpl.java
@@ -37,6 +37,11 @@ public class HashtagRepositoryImpl implements HashtagRepository {
     }
 
     @Override
+    public List<Hashtag> findAllByIds(List<Long> hashtagIds) {
+        return hashtagJpaRepository.findAllById(hashtagIds);
+    }
+
+    @Override
     public List<Hashtag> findTopByUsageCount(int limit) {
         return hashtagJpaRepository.findTopByUsageCount(limit);
     }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/PostHashtagRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/PostHashtagRepositoryImpl.java
@@ -47,4 +47,9 @@ public class PostHashtagRepositoryImpl implements PostHashtagRepository {
     public boolean existsByPostIdAndHashtagId(Long postId, Long hashtagId) {
         return postHashtagJpaRepository.existsByPostIdAndHashtagId(postId, hashtagId);
     }
+
+    @Override
+    public List<PostHashtag> findAllByPostIdIn(List<Long> postIds) {
+        return postHashtagJpaRepository.findAllByPostIdIn(postIds);
+    }
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/PostHashtagJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/PostHashtagJpaRepository.java
@@ -13,4 +13,6 @@ public interface PostHashtagJpaRepository extends JpaRepository<PostHashtag, Lon
     void deleteAllByPostId(Long postId);
 
     boolean existsByPostIdAndHashtagId(Long postId, Long hashtagId);
+
+    List<PostHashtag> findAllByPostIdIn(List<Long> postIds);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/HashtagRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/HashtagRepository.java
@@ -16,9 +16,12 @@ public interface HashtagRepository {
 
     List<Hashtag> findAllByTagNameIn(List<String> tagNames);
 
+    List<Hashtag> findAllByIds(List<Long> hashtagIds);
+
     List<Hashtag> findTopByUsageCount(int limit);
 
     boolean existsByTagName(String tagName);
 
     Page<Hashtag> searchByTagNamePrefix(String keyword, Pageable pageable);
+
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/PostHashtagRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/PostHashtagRepository.java
@@ -18,4 +18,6 @@ public interface PostHashtagRepository {
     void deleteAllByPostId(Long postId);
 
     boolean existsByPostIdAndHashtagId(Long postId, Long hashtagId);
+
+    List<PostHashtag> findAllByPostIdIn(List<Long> postIds);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/HashtagService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/HashtagService.java
@@ -78,12 +78,53 @@ public class HashtagService {
     public List<HashtagResponseDTO> getHashtagsByPostId(Long postId) {
         List<PostHashtag> postHashtags = postHashtagRepository.findAllByPostId(postId);
 
+        if (postHashtags.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<Long> hashtagIds = postHashtags.stream()
+            .map(PostHashtag::getHashtagId)
+            .toList();
+
+        Map<Long, Hashtag> hashtagMap = hashtagRepository.findAllByIds(hashtagIds).stream()
+            .collect(Collectors.toMap(Hashtag::getHashtagId, Function.identity()));
+
         return postHashtags.stream()
-            .map(ph -> hashtagRepository.findById(ph.getHashtagId()))
-            .filter(java.util.Optional::isPresent)
-            .map(java.util.Optional::get)
+            .map(ph -> hashtagMap.get(ph.getHashtagId()))
+            .filter(hashtag -> hashtag != null)
             .map(HashtagResponseDTO::from)
             .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public Map<Long, List<HashtagResponseDTO>> getHashtagsByPostIds(List<Long> postIds) {
+        if (postIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        List<PostHashtag> allPostHashtags = postHashtagRepository.findAllByPostIdIn(postIds);
+
+        if (allPostHashtags.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        List<Long> hashtagIds = allPostHashtags.stream()
+            .map(PostHashtag::getHashtagId)
+            .distinct()
+            .toList();
+
+        Map<Long, Hashtag> hashtagMap = hashtagRepository.findAllByIds(hashtagIds).stream()
+            .collect(Collectors.toMap(Hashtag::getHashtagId, Function.identity()));
+
+        return allPostHashtags.stream()
+            .filter(ph -> hashtagMap.containsKey(ph.getHashtagId()))
+            .collect(Collectors.groupingBy(
+                PostHashtag::getPostId,
+                Collectors.mapping(
+                    ph -> HashtagResponseDTO.from(hashtagMap.get(ph.getHashtagId())),
+                    Collectors.toList()
+                )
+            ));
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
# 변경사항
- 그 전에는 Hashtag가 N개 있다면  N+1 문제가 발생하고 있었습니다.
- 
## 근복적인 원인
- PostHashtag → Hashtag 관계에서 unidirectional ID reference 패턴을 사용하고 있어 JPA의 @ManyToOne fetch join을 사용할 수 없는 구조입니다. 기존 코드는 이 상황에서 findById()를 루프 내에서 개별 호출하고 있었고, 이것이 해시태그 개수에 비례하는 N+1 쿼리를 유발하고 있었습니다.

## 해결 방법
- findById() 루프 → findAllByIds() IN 쿼리 1방으로 전환

## 수정 후
- 해시태그 최대 30개 기준으로 쿼리 2개 고정으로 31개 쿼리 -> 2개로 감소 => -94% 감소 