### PR TITLE
fix: bookmark N+1 문제 해결

### DIFF
--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/PostImageRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/PostImageRepositoryImpl.java
@@ -58,4 +58,9 @@ public class PostImageRepositoryImpl implements PostImageRepository {
     public List<PostImage> findFirstImagesByPostIds(List<Long> postIds) {
         return postImageJpaRepository.findFirstImagesByPostIds(postIds);
     }
+
+    @Override
+    public List<PostImage> findAllByPostIdsOrderByDisplayOrder(List<Long> postIds) {
+        return postImageJpaRepository.findAllByPostIdInOrderByDisplayOrderAsc(postIds);
+    }
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/PostLikeRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/PostLikeRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.prothsync.prothsync.repository.impl;
 import com.prothsync.prothsync.entity.post.PostLike;
 import com.prothsync.prothsync.repository.jpa.PostLikeJpaRepository;
 import com.prothsync.prothsync.repository.repository.PostLikeRepository;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -41,5 +42,10 @@ public class PostLikeRepositoryImpl implements PostLikeRepository {
     @Override
     public int countByPostId(Long postId) {
         return postLikeJpaRepository.countByPostId(postId);
+    }
+
+    @Override
+    public List<Long> findLikedPostIds(Long userId, List<Long> postIds) {
+        return postLikeJpaRepository.findPostIdsByUserIdAndPostIdIn(userId, postIds);
     }
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/PostRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/PostRepositoryImpl.java
@@ -68,4 +68,9 @@ public class PostRepositoryImpl implements PostRepository {
     public long count() {
         return postJpaRepository.count();
     }
+
+    @Override
+    public List<Post> findAllByIds(List<Long> postIds) {
+        return postJpaRepository.findAllByPostIdIn(postIds);
+    }
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/PostImageJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/PostImageJpaRepository.java
@@ -22,4 +22,6 @@ public interface PostImageJpaRepository extends JpaRepository<PostImage, Long> {
     @Query("SELECT pi FROM PostImage pi WHERE pi.postId IN :postIds " +
         "AND pi.displayOrder = (SELECT MIN(pi2.displayOrder) FROM PostImage pi2 WHERE pi2.postId = pi.postId)")
     List<PostImage> findFirstImagesByPostIds(@Param("postIds") List<Long> postIds);
+
+    List<PostImage> findAllByPostIdInOrderByDisplayOrderAsc(List<Long> postIds);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/PostJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/PostJpaRepository.java
@@ -35,4 +35,6 @@ public interface PostJpaRepository extends JpaRepository<Post, Long> {
         """)
     Page<Post> findAllByHashtagIdAndVisibilityPublic(
         @Param("hashtagId") Long hashtagId, Pageable pageable);
+
+    List<Post> findAllByPostIdIn(List<Long> postIds);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/PostLikeJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/PostLikeJpaRepository.java
@@ -1,8 +1,11 @@
 package com.prothsync.prothsync.repository.jpa;
 
 import com.prothsync.prothsync.entity.post.PostLike;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PostLikeJpaRepository extends JpaRepository<PostLike, Long> {
 
@@ -13,4 +16,7 @@ public interface PostLikeJpaRepository extends JpaRepository<PostLike, Long> {
     boolean existsByUserIdAndPostId(Long userId, Long postId);
 
     int countByPostId(Long postId);
+
+    @Query("SELECT pl.postId FROM PostLike pl WHERE pl.userId = :userId AND pl.postId IN :postIds")
+    List<Long> findPostIdsByUserIdAndPostIdIn(@Param("userId") Long userId, @Param("postIds") List<Long> postIds);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/PostImageRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/PostImageRepository.java
@@ -23,4 +23,6 @@ public interface PostImageRepository {
     int countByPostId(Long postId);
 
     List<PostImage> findFirstImagesByPostIds(List<Long> postIds);
+
+    List<PostImage> findAllByPostIdsOrderByDisplayOrder(List<Long> postIds);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/PostLikeRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/PostLikeRepository.java
@@ -1,6 +1,7 @@
 package com.prothsync.prothsync.repository.repository;
 
 import com.prothsync.prothsync.entity.post.PostLike;
+import java.util.List;
 import java.util.Optional;
 
 public interface PostLikeRepository {
@@ -16,4 +17,6 @@ public interface PostLikeRepository {
     boolean existsByUserIdAndPostId(Long userId, Long postId);
 
     int countByPostId(Long postId);
+
+    List<Long> findLikedPostIds(Long userId, List<Long> postIds);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/PostRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/PostRepository.java
@@ -25,4 +25,6 @@ public interface PostRepository {
     Page<Post> findAllByHashtagIdAndVisibilityPublic(Long hashtagId, Pageable pageable);
 
     long count();
+
+    List<Post> findAllByIds(List<Long> postIds);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/BookmarkService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/BookmarkService.java
@@ -12,8 +12,13 @@ import com.prothsync.prothsync.global.PageResponse;
 import com.prothsync.prothsync.repository.repository.BookmarkRepository;
 import com.prothsync.prothsync.repository.repository.PostLikeRepository;
 import com.prothsync.prothsync.repository.repository.PostRepository;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -34,7 +39,7 @@ public class BookmarkService {
     public BookmarkResponseDTO toggleBookmark(Long postId, Long userId) {
         findPostOrThrow(postId);
 
-        Optional<Bookmark> existing = bookmarkRepository.findByUserIdAndPostId(userId, postId);
+        java.util.Optional<Bookmark> existing = bookmarkRepository.findByUserIdAndPostId(userId, postId);
 
         if (existing.isPresent()) {
             bookmarkRepository.delete(existing.get());
@@ -50,16 +55,38 @@ public class BookmarkService {
     public PageResponse<PostResponseDTO> getMyBookmarks(Long userId, Pageable pageable) {
         Page<Bookmark> bookmarkPage = bookmarkRepository.findAllByUserId(userId, pageable);
 
-        List<PostResponseDTO> posts = bookmarkPage.getContent().stream()
-            .map(bookmark -> {
-                Post post = postRepository.findById(bookmark.getPostId())
-                    .orElse(null);
-                if (post == null) {
-                    return null;
-                }
-                return buildPostResponseDTO(post, userId);
-            })
-            .filter(dto -> dto != null)
+        List<Long> postIds = bookmarkPage.getContent().stream()
+            .map(Bookmark::getPostId)
+            .toList();
+
+        if (postIds.isEmpty()) {
+            return PageResponse.of(List.of(), bookmarkPage);
+        }
+
+        // ★ 배치 조회 (총 5 쿼리)
+        Map<Long, Post> postMap = postRepository.findAllByIds(postIds).stream()
+            .collect(Collectors.toMap(Post::getPostId, Function.identity()));
+
+        Map<Long, List<PostImageResponseDTO>> imageMap =
+            postImageService.getImagesByPostIds(postIds);
+
+        Map<Long, List<HashtagResponseDTO>> hashtagMap =
+            hashtagService.getHashtagsByPostIds(postIds);
+
+        Set<Long> likedPostIds = new HashSet<>(
+            postLikeRepository.findLikedPostIds(userId, postIds));
+
+        // ★ DTO 조립 (isBookmarked = 항상 true)
+        List<PostResponseDTO> posts = postIds.stream()
+            .map(postMap::get)
+            .filter(Objects::nonNull)
+            .map(post -> PostResponseDTO.of(
+                post,
+                imageMap.getOrDefault(post.getPostId(), List.of()),
+                hashtagMap.getOrDefault(post.getPostId(), List.of()),
+                likedPostIds.contains(post.getPostId()),
+                true
+            ))
             .toList();
 
         return PageResponse.of(posts, bookmarkPage);
@@ -73,14 +100,5 @@ public class BookmarkService {
     private Post findPostOrThrow(Long postId) {
         return postRepository.findById(postId)
             .orElseThrow(() -> new BusinessException(PostErrorCode.POST_NOT_FOUND));
-    }
-
-    private PostResponseDTO buildPostResponseDTO(Post post, Long currentUserId) {
-        List<PostImageResponseDTO> imageDtos = postImageService.getImagesByPostId(post.getPostId());
-        List<HashtagResponseDTO> hashtagDtos = hashtagService.getHashtagsByPostId(post.getPostId());
-        boolean isLiked = postLikeRepository.existsByUserIdAndPostId(currentUserId, post.getPostId());
-        boolean isBookmarked = bookmarkRepository.existsByUserIdAndPostId(currentUserId, post.getPostId());
-
-        return PostResponseDTO.of(post, imageDtos, hashtagDtos, isLiked, isBookmarked);
     }
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/PostImageService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/PostImageService.java
@@ -75,6 +75,21 @@ public class PostImageService {
             .collect(Collectors.toMap(PostImage::getPostId, PostImage::getImagePath));
     }
 
+    @Transactional(readOnly = true)
+    public Map<Long, List<PostImageResponseDTO>> getImagesByPostIds(List<Long> postIds) {
+        if (postIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        List<PostImage> allImages = postImageRepository.findAllByPostIdsOrderByDisplayOrder(postIds);
+
+        return allImages.stream()
+            .collect(Collectors.groupingBy(
+                PostImage::getPostId,
+                Collectors.mapping(PostImageResponseDTO::from, Collectors.toList())
+            ));
+    }
+
     private void validateImageCount(List<String> imageUrls) {
         if (imageUrls.size() > MAX_IMAGES_PER_POST) {
             throw new BusinessException(PostErrorCode.IMAGE_LIMIT_EXCEEDED);


### PR DESCRIPTION
# 변경사항
- BookmarkService.getMyBookmarks()에서 발생하는 N+1 쿼리 문제를 배치 조회 방식 (지금 까지 했던 수정 방식)으로 수정하여 해결합니다.
- 이를 해결하기위해 post,postImage,PostLike에 배치 조회 메서드를 추가하여 BookmarkService에서 활용합니다.

