### PR TITLE
fix: feed N+1 문제 해결

### DIFF
--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/BookmarkRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/BookmarkRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.prothsync.prothsync.repository.impl;
 import com.prothsync.prothsync.entity.post.Bookmark;
 import com.prothsync.prothsync.repository.jpa.BookmarkJpaRepository;
 import com.prothsync.prothsync.repository.repository.BookmarkRepository;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -43,5 +44,10 @@ public class BookmarkRepositoryImpl implements BookmarkRepository {
     @Override
     public Page<Bookmark> findAllByUserId(Long userId, Pageable pageable) {
         return bookmarkJpaRepository.findAllByUserIdOrderByCreatedAtDesc(userId, pageable);
+    }
+
+    @Override
+    public List<Long> findBookmarkedPostIds(Long userId, List<Long> postIds) {
+        return bookmarkJpaRepository.findPostIdsByUserIdAndPostIdIn(userId, postIds);
     }
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/BookmarkJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/BookmarkJpaRepository.java
@@ -1,10 +1,13 @@
 package com.prothsync.prothsync.repository.jpa;
 
 import com.prothsync.prothsync.entity.post.Bookmark;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BookmarkJpaRepository extends JpaRepository<Bookmark, Long> {
 
@@ -15,4 +18,7 @@ public interface BookmarkJpaRepository extends JpaRepository<Bookmark, Long> {
     Page<Bookmark> findAllByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
 
     void deleteAllByPostId(Long postId);
+
+    @Query("SELECT b.postId FROM Bookmark b WHERE b.userId = :userId AND b.postId IN :postIds")
+    List<Long> findPostIdsByUserIdAndPostIdIn(@Param("userId") Long userId, @Param("postIds") List<Long> postIds);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/BookmarkRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/BookmarkRepository.java
@@ -1,6 +1,7 @@
 package com.prothsync.prothsync.repository.repository;
 
 import com.prothsync.prothsync.entity.post.Bookmark;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -18,4 +19,6 @@ public interface BookmarkRepository {
     boolean existsByUserIdAndPostId(Long userId, Long postId);
 
     Page<Bookmark> findAllByUserId(Long userId, Pageable pageable);
+
+    List<Long> findBookmarkedPostIds(Long userId, List<Long> postIds);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/FeedService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/FeedService.java
@@ -12,6 +12,7 @@ import com.prothsync.prothsync.repository.repository.PostLikeRepository;
 import com.prothsync.prothsync.repository.repository.PostRepository;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -50,21 +51,37 @@ public class FeedService {
 
         Page<Post> postPage = postRepository.findFeedPostsByUserIds(filteredFollowingIds, pageable);
 
-        List<PostResponseDTO> feedPosts = postPage.getContent().stream()
-            .map(post -> buildPostResponseDTO(post, userId))
+        List<Post> posts = postPage.getContent();
+        if (posts.isEmpty()) {
+            return PageResponse.of(List.of(), postPage);
+        }
+
+        List<Long> postIds = posts.stream()
+            .map(Post::getPostId)
+            .toList();
+
+        Map<Long, List<PostImageResponseDTO>> imageMap =
+            postImageService.getImagesByPostIds(postIds);
+
+        Map<Long, List<HashtagResponseDTO>> hashtagMap =
+            hashtagService.getHashtagsByPostIds(postIds);
+
+        Set<Long> likedPostIds = new HashSet<>(
+            postLikeRepository.findLikedPostIds(userId, postIds));
+
+        Set<Long> bookmarkedPostIds = new HashSet<>(
+            bookmarkRepository.findBookmarkedPostIds(userId, postIds));
+
+        List<PostResponseDTO> feedPosts = posts.stream()
+            .map(post -> PostResponseDTO.of(
+                post,
+                imageMap.getOrDefault(post.getPostId(), List.of()),
+                hashtagMap.getOrDefault(post.getPostId(), List.of()),
+                likedPostIds.contains(post.getPostId()),
+                bookmarkedPostIds.contains(post.getPostId())
+            ))
             .toList();
 
         return PageResponse.of(feedPosts, postPage);
-    }
-
-    private PostResponseDTO buildPostResponseDTO(Post post, Long currentUserId) {
-        List<PostImageResponseDTO> imageDtos = postImageService.getImagesByPostId(post.getPostId());
-        List<HashtagResponseDTO> hashtagDtos = hashtagService.getHashtagsByPostId(post.getPostId());
-        boolean isLiked = currentUserId != null
-            && postLikeRepository.existsByUserIdAndPostId(currentUserId, post.getPostId());
-        boolean isBookmarked = currentUserId != null                                    // ★ 추가
-            && bookmarkRepository.existsByUserIdAndPostId(currentUserId, post.getPostId());
-
-        return PostResponseDTO.of(post, imageDtos, hashtagDtos, isLiked, isBookmarked); // ★ 파라미터 추가
     }
 }


### PR DESCRIPTION
# 변경사항
- 드디어 피드에서 발생하는 N+1 문제를 해결하였습니다.
- 피드 N+1 문제를 해결하기 위해서 post 부터 시작해서 해시태그,좋아요, 북마크, 이미지 등 많은 N+1문제를 해결했습니다.
- 그전까지 피드 조회하려면 수많은 쿼리문이 발생하여 굉장히 비효율적이였지만 한단계, 한단계 수정하면서 피드 마저도 수정하였습니다.
- 수정 방법은 그전에 방법들과 같습니다.
- 배치조회 메서드 하나 추가하였습니다.

## 변경 후 성과
그전에는 이번에 피드 수정 전에는 5개 조회만 하더라도 28쿼리, 피드가 20개면 103쿼리 였지만 현재는 8쿼리로 고정됐습니다.