### PR TITLE
fix: 차단 기능 불러오기에서 N+1문제 해결

### DIFF
--- a/prothsync/src/main/java/com/prothsync/prothsync/service/BlockService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/BlockService.java
@@ -13,7 +13,10 @@ import com.prothsync.prothsync.repository.repository.BlockRepository;
 import com.prothsync.prothsync.repository.repository.FollowRepository;
 import com.prothsync.prothsync.repository.repository.UserRepository;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -63,16 +66,29 @@ public class BlockService {
 
         Page<Block> blockPage = blockRepository.findAllByBlockerId(blockerId, pageable);
 
+        List<Long> blockedIds = blockPage.getContent().stream()
+            .map(Block::getBlockedId)
+            .toList();
+
+        if (blockedIds.isEmpty()) {
+            return PageResponse.of(List.of(), blockPage);
+        }
+
+        Map<Long, User> userMap = userRepository.findAllByIds(blockedIds).stream()
+            .collect(Collectors.toMap(User::getUserId, Function.identity()));
+
         List<BlockedUserResponseDTO> blockedUsers = blockPage.getContent().stream()
             .map(block -> {
-                User blockedUser = findUserOrThrow(block.getBlockedId());
+                User blockedUser = userMap.get(block.getBlockedId());
+                if (blockedUser == null) {
+                    throw new BusinessException(UserErrorCode.USER_NOT_FOUND);
+                }
                 return BlockedUserResponseDTO.of(blockedUser, block.getCreatedAt());
             })
             .toList();
 
         return PageResponse.of(blockedUsers, blockPage);
     }
-
     @Transactional(readOnly = true)
     public boolean isBlocked(Long blockerId, Long blockedId) {
         return blockRepository.existsByBlockerIdAndBlockedId(blockerId, blockedId);


### PR DESCRIPTION
# 변경사항
- 차단 목록을 불러오면서 User select를 List만큼 반복하는 일이 있었는데 이 현상을 수정하였습니다.
- 방법은 다른 N+1 문제와 동일합니다. 그대신 이제 배치 조회 메서드가 잘 처리되어있으니 이를 이용하여 처리하였습니다. 