### PR TITLE
fix: 게시글 조회수 레디스 캐싱

### DIFF
--- a/prothsync/src/main/java/com/prothsync/prothsync/ProthSyncApplication.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/ProthSyncApplication.java
@@ -2,7 +2,9 @@ package com.prothsync.prothsync;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class ProthSyncApplication {
 

--- a/prothsync/src/main/java/com/prothsync/prothsync/dto/PostResponseDTO.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/dto/PostResponseDTO.java
@@ -47,4 +47,30 @@ public record PostResponseDTO(
             post.getUpdatedAt()
         );
     }
+
+    public static PostResponseDTO ofWithViewCount(
+        Post post,
+        List<PostImageResponseDTO> images,
+        List<HashtagResponseDTO> hashtags,
+        boolean isLiked,
+        boolean isBookmarked,
+        int viewCount
+    ) {
+        return new PostResponseDTO(
+            post.getPostId(),
+            post.getUserId(),
+            post.getContent(),
+            post.getCategory(),
+            post.getVisibility(),
+            images,
+            hashtags,
+            post.getLikeCount(),
+            post.getCommentCount(),
+            viewCount,
+            isLiked,
+            isBookmarked,
+            post.getCreatedAt(),
+            post.getUpdatedAt()
+        );
+    }
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/entity/post/Post.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/entity/post/Post.java
@@ -127,10 +127,6 @@ public class Post extends BaseEntity {
         }
     }
 
-    public void incrementViewCount() {
-        this.viewCount++;
-    }
-
     public boolean isOwner(Long userId) {
         return this.userId.equals(userId);
     }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/PostRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/PostRepositoryImpl.java
@@ -73,4 +73,9 @@ public class PostRepositoryImpl implements PostRepository {
     public List<Post> findAllByIds(List<Long> postIds) {
         return postJpaRepository.findAllByPostIdIn(postIds);
     }
+
+    @Override
+    public void incrementViewCount(Long postId, int delta){
+        postJpaRepository.incrementViewCount(postId,delta);
+    }
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/PostJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/PostJpaRepository.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -37,4 +38,8 @@ public interface PostJpaRepository extends JpaRepository<Post, Long> {
         @Param("hashtagId") Long hashtagId, Pageable pageable);
 
     List<Post> findAllByPostIdIn(List<Long> postIds);
+
+    @Modifying
+    @Query("UPDATE Post p SET p.viewCount = p.viewCount + :delta WHERE p.postId = :postId")
+    void incrementViewCount(@Param("postId") Long postId, @Param("delta") int delta);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/PostRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/PostRepository.java
@@ -27,4 +27,6 @@ public interface PostRepository {
     long count();
 
     List<Post> findAllByIds(List<Long> postIds);
+
+    void incrementViewCount(Long postId, int delta);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/scheduler/ViewCountFlushScheduler.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/scheduler/ViewCountFlushScheduler.java
@@ -1,0 +1,27 @@
+package com.prothsync.prothsync.scheduler;
+
+import com.prothsync.prothsync.service.PostViewCountService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ViewCountFlushScheduler {
+
+    private final PostViewCountService postViewCountService;
+
+    /**
+     * 1분 주기로 Redis에 쌓인 조회수를 DB에 flush
+     */
+    @Scheduled(fixedRate = 60_000)
+    public void flushViewCounts() {
+        try {
+            postViewCountService.flushViewCountsToDb();
+        } catch (Exception e) {
+            log.error("조회수 flush 실패", e);
+        }
+    }
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/PostService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/PostService.java
@@ -37,6 +37,7 @@ public class PostService {
     private final PostImageService postImageService;
     private final CommentService commentService;
     private final BookmarkRepository bookmarkRepository;
+    private final PostViewCountService postViewCountService;
 
     @Transactional
     public PostResponseDTO createPost(Long userId, PostCreateRequestDTO request) {
@@ -53,15 +54,14 @@ public class PostService {
         return toPostResponseDTO(savedPost, savedImages, hashtags, false);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public PostResponseDTO getPost(Long postId, Long currentUserId) {
         Post post = findPostOrThrow(postId);
         validatePostAccess(post, currentUserId);
 
-        post.incrementViewCount();
-        postRepository.save(post);
+        postViewCountService.increaseViewCount(postId);
 
-        return buildPostResponseDTO(post, currentUserId);
+        return buildPostResponseDTOWithViewCount(post, currentUserId);
     }
 
     @Transactional(readOnly = true)
@@ -165,6 +165,21 @@ public class PostService {
             && bookmarkRepository.existsByUserIdAndPostId(currentUserId, post.getPostId());
 
         return PostResponseDTO.of(post, imageDtos, hashtagDtos, isLiked, isBookmarked);
+    }
+
+    private PostResponseDTO buildPostResponseDTOWithViewCount(Post post, Long currentUserId) {
+        List<PostImageResponseDTO> imageDtos = postImageService.getImagesByPostId(post.getPostId());
+        List<HashtagResponseDTO> hashtagDtos = hashtagService.getHashtagsByPostId(post.getPostId());
+        boolean isLiked = currentUserId != null
+            && postLikeRepository.existsByUserIdAndPostId(currentUserId, post.getPostId());
+        boolean isBookmarked = currentUserId != null
+            && bookmarkRepository.existsByUserIdAndPostId(currentUserId, post.getPostId());
+
+        int redisDelta = postViewCountService.getViewCountDelta(post.getPostId());
+        int realTimeViewCount = post.getViewCount() + redisDelta;
+
+        return PostResponseDTO.ofWithViewCount(
+            post, imageDtos, hashtagDtos, isLiked, isBookmarked, realTimeViewCount);
     }
 
     private PostResponseDTO toPostResponseDTO(

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/PostViewCountService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/PostViewCountService.java
@@ -1,0 +1,74 @@
+package com.prothsync.prothsync.service;
+
+import com.prothsync.prothsync.repository.jpa.PostJpaRepository;
+import com.prothsync.prothsync.repository.repository.PostRepository;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PostViewCountService {
+
+    private static final String VIEW_COUNT_KEY_PREFIX = "post:viewcount:";
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final PostRepository postRepository;
+
+    /**
+     * 조회수 증가 — Redis INCR (DB 접근 없음, O(1) atomic)
+     */
+    public void increaseViewCount(Long postId) {
+        String key = VIEW_COUNT_KEY_PREFIX + postId;
+        redisTemplate.opsForValue().increment(key);
+    }
+
+    /**
+     * Redis에 쌓인 delta 값 조회 (DTO 응답 시 DB값과 합산용)
+     */
+    public int getViewCountDelta(Long postId) {
+        String key = VIEW_COUNT_KEY_PREFIX + postId;
+        String value = redisTemplate.opsForValue().get(key);
+        return value != null ? Integer.parseInt(value) : 0;
+    }
+
+    /**
+     * 스케줄러에서 호출 — Redis에 쌓인 조회수 delta를 DB에 일괄 반영 후 키 삭제
+     *
+     * getAndDelete()를 사용하여 읽기+삭제를 atomic하게 처리하고,
+     * flush 중 유입되는 새 조회수 유실을 방지한다.
+     */
+    @Transactional
+    public void flushViewCountsToDb() {
+        Set<String> keys = redisTemplate.keys(VIEW_COUNT_KEY_PREFIX + "*");
+        if (keys == null || keys.isEmpty()) {
+            return;
+        }
+
+        int flushedCount = 0;
+
+        for (String key : keys) {
+            String value = redisTemplate.opsForValue().getAndDelete(key);
+            if (value == null) {
+                continue;
+            }
+
+            int delta = Integer.parseInt(value);
+            if (delta <= 0) {
+                continue;
+            }
+
+            Long postId = Long.parseLong(key.replace(VIEW_COUNT_KEY_PREFIX, ""));
+            postRepository.incrementViewCount(postId, delta);
+            flushedCount++;
+        }
+
+        if (flushedCount > 0) {
+            log.info("조회수 flush 완료 - {}개 게시글 반영", flushedCount);
+        }
+    }
+}


### PR DESCRIPTION
# 변경사항
- 게시글 조회 시 매 요청 마다 발생하던 DB UPDATE를 제거하고, Redis INCR로 조회수를 누적한 뒤 스케줄러를 통해 주기적으로 DB에 일괄반영하는 Write-Behind 캐싱 패턴을 도입했습니다.

## 전 구조 문제점
```
요청 -> select -> post.incrementViewCount()->repository.save()-> update
```
- 이 방식에는 3가지 문제가 발생하는데

### 문제점1. 매 조회마다 불필요한 DB Write 발생
- postRepository.save(post)는 jpa dirty checking에 의해 게시글의 모든 컬럼을 포함하는 update쿼리를 실행하는데 조회 1을 증가시키기위해 변경되지 않은 컬럼까지 매번 update를 한다.

### 문제점2. 동시성 환경에서 Lost update
- post.incrementViewCount()는 애플리케이션 레벨의 read-modify-write 패턴이다:
```
Thread A: read viewCount=100 → viewCount=101 → save(101)
Thread B: read viewCount=100 → viewCount=101 → save(101)
→ 실제 기대값: 102, 저장값: 101 (1회 유실)
```

### 문제점3. 읽기 전용 작업에 쓰기 트랜잭션 사용
- 게시글 단건 조회는 읽기 작업이지만 viewCount update때문에 쓰기 트랜잭션을 써야 하기 때문 JPA 성능 최적화 측면에서 비효율적입니다.

이를 위해 redis를 사용하여 write-behind 패턴을 도입하였습니다.
