### PR TITLE
fix: refreshtoken 전달 방식을 응답 Body에서 HttpOnly Cookie로 변경

### DIFF
--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/AuthController.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/AuthController.java
@@ -5,17 +5,22 @@ import com.prothsync.prothsync.dto.LoginRequestDTO;
 import com.prothsync.prothsync.dto.LoginResponseDTO;
 import com.prothsync.prothsync.dto.SignupRequestDTO;
 import com.prothsync.prothsync.dto.SignupResponseDTO;
-import com.prothsync.prothsync.dto.TokenRefreshRequestDTO;
 import com.prothsync.prothsync.dto.TokenRefreshResponseDTO;
 import com.prothsync.prothsync.entity.user.User;
 import com.prothsync.prothsync.security.CustomUserDetails;
 import com.prothsync.prothsync.service.AuthService;
+import com.prothsync.prothsync.vo.LoginResult;
+import com.prothsync.prothsync.vo.RefreshResult;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,6 +33,8 @@ public class AuthController implements AuthControllerDocs {
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";
+    private static final String REFRESH_TOKEN_COOKIE = "refreshToken";
+    private static final int REFRESH_TOKEN_MAX_AGE = 7 * 24 * 60 * 60; // 7일 (초)
 
     private final AuthService authService;
 
@@ -38,26 +45,70 @@ public class AuthController implements AuthControllerDocs {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<LoginResponseDTO> login(@Valid @RequestBody LoginRequestDTO loginRequest) {
-        LoginResponseDTO response = authService.login(loginRequest);
-        return ResponseEntity.ok(response);
+    public ResponseEntity<LoginResponseDTO> login(
+        @Valid @RequestBody LoginRequestDTO loginRequest,
+        HttpServletResponse response
+    ) {
+        LoginResult result = authService.login(loginRequest);
+
+        addRefreshTokenCookie(response, result.refreshToken());
+
+        return ResponseEntity.ok(LoginResponseDTO.of(
+            result.accessToken(),
+            result.userId(),
+            result.userName(),
+            result.nickName()
+        ));
     }
 
     @PostMapping("/refresh")
     public ResponseEntity<TokenRefreshResponseDTO> refreshToken(
-        @Valid @RequestBody TokenRefreshRequestDTO refreshRequest) {
-        TokenRefreshResponseDTO response = authService.refreshToken(refreshRequest.refreshToken());
-        return ResponseEntity.ok(response);
+        @CookieValue(name = REFRESH_TOKEN_COOKIE) String refreshToken,
+        HttpServletResponse response
+    ) {
+        RefreshResult result = authService.refreshToken(refreshToken);
+
+        addRefreshTokenCookie(response, result.refreshToken());
+
+        return ResponseEntity.ok(TokenRefreshResponseDTO.of(result.accessToken()));
     }
 
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(
         @AuthenticationPrincipal CustomUserDetails userDetails,
-        HttpServletRequest request
+        HttpServletRequest request,
+        HttpServletResponse response
     ) {
         String accessToken = resolveToken(request);
         authService.logout(userDetails.getUserId(), accessToken);
+
+        clearRefreshTokenCookie(response);
+
         return ResponseEntity.ok().build();
+    }
+
+    private void addRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+        ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE, refreshToken)
+            .httpOnly(true)
+            .secure(true)
+            .path("/api/auth")
+            .maxAge(REFRESH_TOKEN_MAX_AGE)
+            .sameSite("Strict")
+            .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
+    private void clearRefreshTokenCookie(HttpServletResponse response) {
+        ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE, "")
+            .httpOnly(true)
+            .secure(true)
+            .path("/api/auth")
+            .maxAge(0)
+            .sameSite("Strict")
+            .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 
     private String resolveToken(HttpServletRequest request) {

--- a/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/AuthControllerDocs.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/controller/docs/AuthControllerDocs.java
@@ -4,11 +4,11 @@ import com.prothsync.prothsync.dto.LoginRequestDTO;
 import com.prothsync.prothsync.dto.LoginResponseDTO;
 import com.prothsync.prothsync.dto.SignupRequestDTO;
 import com.prothsync.prothsync.dto.SignupResponseDTO;
-import com.prothsync.prothsync.dto.TokenRefreshRequestDTO;
 import com.prothsync.prothsync.dto.TokenRefreshResponseDTO;
 import com.prothsync.prothsync.exception.ErrorResponse;
 import com.prothsync.prothsync.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
 
 @Tag(name = "인증", description = "회원가입, 로그인, 로그아웃, 토큰 갱신 API")
@@ -41,11 +42,15 @@ public interface AuthControllerDocs {
     })
     ResponseEntity<SignupResponseDTO> signup(SignupRequestDTO signupRequest);
 
-    @Operation(summary = "로그인", description = "아이디와 비밀번호로 로그인하여 JWT 토큰을 발급받습니다.")
+    @Operation(
+        summary = "로그인",
+        description = "아이디와 비밀번호로 로그인합니다. "
+            + "Access Token은 응답 body로, Refresh Token은 HttpOnly Cookie로 발급됩니다."
+    )
     @ApiResponses({
         @ApiResponse(
             responseCode = "200",
-            description = "로그인 성공",
+            description = "로그인 성공 (Set-Cookie 헤더에 refreshToken 포함)",
             content = @Content(schema = @Schema(implementation = LoginResponseDTO.class))
         ),
         @ApiResponse(
@@ -64,19 +69,23 @@ public interface AuthControllerDocs {
             content = @Content(schema = @Schema(implementation = ErrorResponse.class))
         )
     })
-    ResponseEntity<LoginResponseDTO> login(LoginRequestDTO loginRequest);
+    ResponseEntity<LoginResponseDTO> login(LoginRequestDTO loginRequest, HttpServletResponse response);
 
-    @Operation(summary = "토큰 갱신", description = "Refresh Token을 사용하여 새로운 Access Token과 Refresh Token을 발급받습니다.")
+    @Operation(
+        summary = "토큰 갱신",
+        description = "HttpOnly Cookie의 Refresh Token을 사용하여 새로운 Access Token과 Refresh Token을 발급받습니다. "
+            + "새로운 Refresh Token은 HttpOnly Cookie로 갱신됩니다."
+    )
     @ApiResponses({
         @ApiResponse(
             responseCode = "200",
-            description = "토큰 갱신 성공",
+            description = "토큰 갱신 성공 (Set-Cookie 헤더에 새 refreshToken 포함)",
             content = @Content(schema = @Schema(implementation = TokenRefreshResponseDTO.class))
         ),
         @ApiResponse(
             responseCode = "400",
-            description = "유효성 검증 실패",
-            content = @Content(schema = @Schema(implementation = String.class))
+            description = "Refresh Token 쿠키 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
         ),
         @ApiResponse(
             responseCode = "401",
@@ -84,11 +93,15 @@ public interface AuthControllerDocs {
             content = @Content(schema = @Schema(implementation = ErrorResponse.class))
         )
     })
-    ResponseEntity<TokenRefreshResponseDTO> refreshToken(TokenRefreshRequestDTO refreshRequest);
+    ResponseEntity<TokenRefreshResponseDTO> refreshToken(
+        @Parameter(description = "HttpOnly Cookie에서 자동 전송되는 Refresh Token", hidden = true)
+        String refreshToken,
+        HttpServletResponse response
+    );
 
     @Operation(
         summary = "로그아웃",
-        description = "현재 사용자를 로그아웃하고 토큰을 무효화합니다.",
+        description = "현재 사용자를 로그아웃하고 토큰을 무효화합니다. Refresh Token 쿠키도 삭제됩니다.",
         security = @SecurityRequirement(name = "bearerAuth")
     )
     @ApiResponses({
@@ -102,5 +115,5 @@ public interface AuthControllerDocs {
             content = @Content(schema = @Schema(implementation = ErrorResponse.class))
         )
     })
-    ResponseEntity<Void> logout(CustomUserDetails userDetails, HttpServletRequest request);
+    ResponseEntity<Void> logout(CustomUserDetails userDetails, HttpServletRequest request, HttpServletResponse response);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/dto/LoginResponseDTO.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/dto/LoginResponseDTO.java
@@ -2,13 +2,12 @@ package com.prothsync.prothsync.dto;
 
 public record LoginResponseDTO(
     String accessToken,
-    String refreshToken,
     Long userId,
     String userName,
     String nickName
 ) {
-    public static LoginResponseDTO of(String accessToken, String refreshToken,
+    public static LoginResponseDTO of(String accessToken,
         Long userId, String userName, String nickName) {
-        return new LoginResponseDTO(accessToken, refreshToken, userId, userName, nickName);
+        return new LoginResponseDTO(accessToken, userId, userName, nickName);
     }
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/dto/TokenRefreshRequestDTO.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/dto/TokenRefreshRequestDTO.java
@@ -1,10 +1,10 @@
-package com.prothsync.prothsync.dto;
-
-import jakarta.validation.constraints.NotBlank;
-
-public record TokenRefreshRequestDTO(
-
-    @NotBlank(message = "리프레시 토큰은 필수입니다.")
-    String refreshToken
-) {
-}
+//package com.prothsync.prothsync.dto;
+//
+//import jakarta.validation.constraints.NotBlank;
+//
+//public record TokenRefreshRequestDTO(
+//
+////    @NotBlank(message = "리프레시 토큰은 필수입니다.")
+////    String refreshToken
+//) {
+//}

--- a/prothsync/src/main/java/com/prothsync/prothsync/dto/TokenRefreshResponseDTO.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/dto/TokenRefreshResponseDTO.java
@@ -1,10 +1,9 @@
 package com.prothsync.prothsync.dto;
 
 public record TokenRefreshResponseDTO(
-    String accessToken,
-    String refreshToken
+    String accessToken
 ) {
-    public static TokenRefreshResponseDTO of(String accessToken, String refreshToken) {
-        return new TokenRefreshResponseDTO(accessToken, refreshToken);
+    public static TokenRefreshResponseDTO of(String accessToken) {
+        return new TokenRefreshResponseDTO(accessToken);
     }
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/AuthService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/AuthService.java
@@ -1,9 +1,7 @@
 package com.prothsync.prothsync.service;
 
 import com.prothsync.prothsync.dto.LoginRequestDTO;
-import com.prothsync.prothsync.dto.LoginResponseDTO;
 import com.prothsync.prothsync.dto.SignupRequestDTO;
-import com.prothsync.prothsync.dto.TokenRefreshResponseDTO;
 import com.prothsync.prothsync.entity.RefreshToken;
 import com.prothsync.prothsync.entity.user.User;
 import com.prothsync.prothsync.exception.AuthErrorCode;
@@ -13,6 +11,8 @@ import com.prothsync.prothsync.repository.repository.RefreshTokenRepository;
 import com.prothsync.prothsync.repository.repository.UserRepository;
 import com.prothsync.prothsync.security.JwtTokenProvider;
 import com.prothsync.prothsync.service.GeocodingService.GeocodingResult;
+import com.prothsync.prothsync.vo.LoginResult;
+import com.prothsync.prothsync.vo.RefreshResult;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -55,7 +55,7 @@ public class AuthService {
     }
 
     @Transactional
-    public LoginResponseDTO login(LoginRequestDTO loginRequest) {
+    public LoginResult login(LoginRequestDTO loginRequest) {
         User user = userRepository.findByUserName(loginRequest.userName())
             .orElseThrow(() -> new BusinessException(AuthErrorCode.INVALID_CREDENTIALS));
 
@@ -76,7 +76,7 @@ public class AuthService {
 
         saveOrUpdateRefreshToken(user.getUserId(), refreshToken);
 
-        return LoginResponseDTO.of(
+        return new LoginResult(
             accessToken,
             refreshToken,
             user.getUserId(),
@@ -86,7 +86,7 @@ public class AuthService {
     }
 
     @Transactional
-    public TokenRefreshResponseDTO refreshToken(String refreshTokenValue) {
+    public RefreshResult refreshToken(String refreshTokenValue) {
         if (!jwtTokenProvider.validateToken(refreshTokenValue)) {
             throw new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
         }
@@ -121,7 +121,7 @@ public class AuthService {
         storedToken.updateToken(newRefreshToken, jwtTokenProvider.getRefreshTokenExpiration());
         refreshTokenRepository.save(storedToken);
 
-        return TokenRefreshResponseDTO.of(newAccessToken, newRefreshToken);
+        return new RefreshResult(newAccessToken, newRefreshToken);
     }
 
     @Transactional

--- a/prothsync/src/main/java/com/prothsync/prothsync/vo/LoginResult.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/vo/LoginResult.java
@@ -1,0 +1,11 @@
+package com.prothsync.prothsync.vo;
+
+public record LoginResult(
+    String accessToken,
+    String refreshToken,
+    Long userId,
+    String userName,
+    String nickName
+) {
+
+}

--- a/prothsync/src/main/java/com/prothsync/prothsync/vo/RefreshResult.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/vo/RefreshResult.java
@@ -1,0 +1,8 @@
+package com.prothsync.prothsync.vo;
+
+public record RefreshResult(
+    String accessToken,
+    String refreshToken
+) {
+
+}


### PR DESCRIPTION
# 변경사항
- Refresh Token의 전달 방식을 응답 Body에서 HttpOnly Cookie로 변경하여 XSS 기반 토큰 탈취를 방지합니다.
- 기존에는 로그인/토큰 갱신 시 AccessToken이랑 Refresh Token을 모두 JSON 응답 Body로 주었고 , 프론트엔드에서는 두 토큰 모두 localStorage에 저장하고 있었습니다.
- 그런데  이 구조에서는 XSS 공격으로 악성 스크립트가 주입될 경우 localStorage.getItem('refreshToken') 한 줄로
Refresh Token이 탈취되어 장기간 세션 하이재킹이 가능한 보안 취약점이 존재했습니다.

## VO 를 추가한 이유
- 기존에는 AuthService.login()이 LoginResponseDTO를 직접 반환했고 여기에 DTO에 모든 토큰이 담겨있었습니다.
- 하지만 이번에 DTO에서 Refresh Token이 빠지면서  Service -> Controller 간 Token 전달 수단이 필요해져서 만들었습니다.