### PR TITLE
feat: 토큰을 zustand를 이용하여 관리 하는 걸로 변경

### DIFF
--- a/prothsyncFront/package-lock.json
+++ b/prothsyncFront/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^6.28.0"
+        "react-router-dom": "^6.28.0",
+        "zustand": "^5.0.0"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.3.4",
@@ -1831,6 +1832,35 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/zustand": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
+      "integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/prothsyncFront/package.json
+++ b/prothsyncFront/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.28.0"
+    "react-router-dom": "^6.28.0",
+    "zustand": "^5.0.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.4",

--- a/prothsyncFront/src/App.jsx
+++ b/prothsyncFront/src/App.jsx
@@ -1,10 +1,34 @@
+import { useEffect } from 'react';
 import { BrowserRouter } from 'react-router-dom';
+import useAuthStore from './store/useAuthStore';
 import Navbar from './components/Navbar';
 import Footer from './components/Footer';
 import ScrollToTop from './components/ScrollToTop';
 import AppRouter from './router/AppRouter';
 
 export default function App() {
+  const isReady = useAuthStore((state) => state.isReady);
+  const initAuth = useAuthStore((state) => state.initAuth);
+
+  useEffect(() => {
+    initAuth();
+  }, [initAuth]);
+
+  if (!isReady) {
+    return (
+      <div style={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        height: '100vh',
+        fontSize: '1rem',
+        color: '#888',
+      }}>
+        로딩 중...
+      </div>
+    );
+  }
+
   return (
     <BrowserRouter>
       <ScrollToTop />

--- a/prothsyncFront/src/components/Navbar.jsx
+++ b/prothsyncFront/src/components/Navbar.jsx
@@ -1,16 +1,37 @@
 import { useEffect, useState } from 'react';
-import { NavLink, Link } from 'react-router-dom';
+import { NavLink, Link, useNavigate } from 'react-router-dom';
+import useAuthStore from '../store/useAuthStore';
+import { apiFetch } from '../utils/api';
 import './Navbar.css';
 
 export default function Navbar() {
   const [scrolled, setScrolled] = useState(false);
   const [mobileOpen, setMobileOpen] = useState(false);
 
+  const accessToken = useAuthStore((state) => state.accessToken);
+  const user = useAuthStore((state) => state.user);
+  const clearAuth = useAuthStore((state) => state.clearAuth);
+  const navigate = useNavigate();
+
+  const isLoggedIn = accessToken !== null;
+
   useEffect(() => {
     const onScroll = () => setScrolled(window.scrollY > 50);
     window.addEventListener('scroll', onScroll);
     return () => window.removeEventListener('scroll', onScroll);
   }, []);
+
+  const handleLogout = async () => {
+    try {
+      await apiFetch('/auth/logout', { method: 'POST' });
+    } catch {
+      // 로그아웃 API 실패해도 클라이언트에서는 정리
+    } finally {
+      clearAuth();
+      setMobileOpen(false);
+      navigate('/');
+    }
+  };
 
   return (
     <nav className={`nav${scrolled ? ' nav--scrolled' : ''}`}>
@@ -34,9 +55,19 @@ export default function Navbar() {
         <NavLink to="/users" onClick={() => setMobileOpen(false)}>사용자</NavLink>
         <NavLink to="/cases" onClick={() => setMobileOpen(false)}>의뢰</NavLink>
         <NavLink to="/feed" onClick={() => setMobileOpen(false)}>피드</NavLink>
-        <Link to="/login" className="nav-cta" onClick={() => setMobileOpen(false)}>
-          시작하기 →
-        </Link>
+
+        {isLoggedIn ? (
+          <>
+            <span className="nav-user">{user?.nickName || user?.userName}</span>
+            <button className="nav-cta nav-logout-btn" onClick={handleLogout}>
+              로그아웃
+            </button>
+          </>
+        ) : (
+          <Link to="/login" className="nav-cta" onClick={() => setMobileOpen(false)}>
+            시작하기 →
+          </Link>
+        )}
       </div>
     </nav>
   );

--- a/prothsyncFront/src/pages/LoginPage.jsx
+++ b/prothsyncFront/src/pages/LoginPage.jsx
@@ -1,9 +1,11 @@
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import useAuthStore from '../store/useAuthStore';
 import './Auth.css';
 
 export default function LoginPage() {
   const navigate = useNavigate();
+  const setAuth = useAuthStore((state) => state.setAuth);
   const [form, setForm] = useState({ userName: '', password: '' });
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
@@ -21,6 +23,7 @@ export default function LoginPage() {
       const res = await fetch('/api/auth/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',  // Set-Cookie 수신
         body: JSON.stringify(form),
       });
 
@@ -30,8 +33,14 @@ export default function LoginPage() {
       }
 
       const data = await res.json();
-      localStorage.setItem('accessToken', data.accessToken);
-      localStorage.setItem('refreshToken', data.refreshToken);
+
+      // accessToken + user 정보만 인메모리 저장 (refreshToken은 Cookie에 자동 저장됨)
+      setAuth(data.accessToken, {
+        userId: data.userId,
+        userName: data.userName,
+        nickName: data.nickName,
+      });
+
       navigate('/');
     } catch (err) {
       setError(err.message);

--- a/prothsyncFront/src/utils/api.js
+++ b/prothsyncFront/src/utils/api.js
@@ -1,26 +1,84 @@
+import useAuthStore from '../store/useAuthStore';
+
 const BASE_URL = '/api';
 
+// refresh 중복 호출 방지
+let refreshPromise = null;
+
+async function refreshAccessToken() {
+  // 이미 refresh 진행 중이면 같은 Promise 공유
+  if (refreshPromise) return refreshPromise;
+
+  refreshPromise = (async () => {
+    try {
+      const res = await fetch(`${BASE_URL}/auth/refresh`, {
+        method: 'POST',
+        credentials: 'include',
+      });
+
+      if (!res.ok) return null;
+
+      const data = await res.json();
+      return data.accessToken;
+    } catch {
+      return null;
+    } finally {
+      refreshPromise = null;
+    }
+  })();
+
+  return refreshPromise;
+}
+
 export async function apiFetch(path, options = {}) {
-  const token = localStorage.getItem('accessToken');
+  const { accessToken } = useAuthStore.getState();
 
   const headers = {
     'Content-Type': 'application/json',
     ...options.headers,
   };
 
-  if (token) {
-    headers['Authorization'] = `Bearer ${token}`;
+  if (accessToken) {
+    headers['Authorization'] = `Bearer ${accessToken}`;
   }
 
   const res = await fetch(`${BASE_URL}${path}`, {
     ...options,
     headers,
+    credentials: 'include',
   });
 
-  // 401이면 토큰 만료 → 로그인 페이지로
+  // 401 → refresh 시도 후 원래 요청 재시도
   if (res.status === 401) {
-    localStorage.removeItem('accessToken');
-    localStorage.removeItem('refreshToken');
+    const newToken = await refreshAccessToken();
+
+    if (newToken) {
+      // refresh 성공 → store 업데이트 + 원래 요청 재시도
+      useAuthStore.getState().setAuth(
+        newToken,
+        useAuthStore.getState().user
+      );
+
+      const retryRes = await fetch(`${BASE_URL}${path}`, {
+        ...options,
+        headers: {
+          ...headers,
+          'Authorization': `Bearer ${newToken}`,
+        },
+        credentials: 'include',
+      });
+
+      if (!retryRes.ok) {
+        const data = await retryRes.json().catch(() => ({}));
+        throw new Error(data.message || '요청에 실패했습니다.');
+      }
+
+      if (retryRes.status === 204) return null;
+      return retryRes.json();
+    }
+
+    // refresh 실패 → 로그아웃 처리
+    useAuthStore.getState().clearAuth();
     window.location.href = '/login';
     throw new Error('인증이 만료되었습니다.');
   }
@@ -30,7 +88,7 @@ export async function apiFetch(path, options = {}) {
     throw new Error(data.message || '요청에 실패했습니다.');
   }
 
-  // 204 No Content인 경우
+  // 204 No Content
   if (res.status === 204) return null;
 
   return res.json();


### PR DESCRIPTION
# 변경사항
- Access Token 저장소를 localStorage에서 Zustand 임네모리 store로 전환하고, Refresh Token은 백엔드에서 HttpOnly Cookie로 내려주는 구조에 맞춰 프론트 엔드 인증 플로우를 전면 재구성합니다.

# 변경 배경
## 변경 전
```
[LoginPage.jsx]
localStorage.setItem('accessToken', data.accessToken);   ← XSS 취약
localStorage.setItem('refreshToken', data.refreshToken);  ← XSS 취약

[api.js]
const token = localStorage.getItem('accessToken');         ← XSS 취약
```
#3 변경 후
```
[LoginPage.jsx]
useAuthStore.setAuth(data.accessToken, { userId, userName, nickName });
→ Zustand 인메모리 저장 (JavaScript 변수, XSS로 직접 접근 불가)

[api.js]
const { accessToken } = useAuthStore.getState();
→ 메모리에서 읽기

[refreshToken]
→ 프론트엔드 코드에서 일절 다루지 않음 (Cookie 세팅/전송 모두 브라우저가 처리)
```

#Zustand를 고른 이유
- api.js는 React 컴포넌트가 아니라 순수 유틸리티 함수인데, useAuthStore.getState()로 hook 없이 store에 접근할 수 있는 점이 Zustand 선택의 결정적 이유였습니다.

