### PR TITLE
feat: 프로메테우스, 그라파나 대시보드 구성

### DIFF
--- a/prothsync/compose.yaml
+++ b/prothsync/compose.yaml
@@ -27,6 +27,35 @@ services:
     volumes:
       - prothSync_redis_data:/data
 
+  prometheus:
+    image: 'prom/prometheus:latest'
+    container_name: prometheus-prothSync
+    volumes:
+      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+      - prothSync_prometheus_data:/prometheus
+    ports:
+      - "9090:9090"
+    networks:
+      - db-net
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  grafana:
+    image: 'grafana/grafana:latest'
+    container_name: grafana-prothSync
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+      TZ: ${TZ}
+    volumes:
+      - prothSync_grafana_data:/var/lib/grafana
+    ports:
+      - "3000:3000"
+    networks:
+      - db-net
+    depends_on:
+      - prometheus
+
 networks:
   db-net:
     name: db-net
@@ -34,3 +63,5 @@ networks:
 volumes:
   prothSync_postgres_data:
   prothSync_redis_data:
+  prothSync_prometheus_data:
+  prothSync_grafana_data:

--- a/prothsync/monitoring/prometheus/prometheus.yml
+++ b/prothsync/monitoring/prometheus/prometheus.yml
@@ -7,5 +7,3 @@ scrape_configs:
     metrics_path: '/actuator/prometheus'
     static_configs:
       - targets: ['host.docker.internal:8080']
-        labels:
-          application: 'prothsync'


### PR DESCRIPTION
# 변경사항
- docker-compose에 그라파나랑 프로메테우스 추가하였습니다.
- 그리고 prometheus.yml에서 label에서 충돌이 생겨서 지웠습니다. => micrometer가 이미 application = prothsync 태그를 부여하므로, exported_application 충돌 발생해서 삭제했습니다.

- 그리고 대쉬보드 구성할때 19004로 설정하였습니다.
- 4701 이랑  6756 은 안떠서 19004로 하였더니 잘떴습니다.

## 그리고 수정한 거
- 처음에 대시 보드 설정하니까 전부다 N/A로 떴었습니다. => 4701 이랑 6756
- 그래서 19004로 먼저 import하고 
- setting에 들어가서 JSON Model에 들어가서  ${DS_PROMETHEUS} 이거를 컨트롤 h로 찾은 다음 프로메테우스 uid로 바꿔줬습니다. 

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/af4e1471-efba-48e2-ad91-aa300119b4bf" />
