### PR TITLE
fix: 사용자 정지 시 Refresh Token 무효화

### DIFF
--- a/prothsync/src/main/java/com/prothsync/prothsync/service/AdminService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/AdminService.java
@@ -25,6 +25,7 @@ import com.prothsync.prothsync.repository.repository.CaseRequestRepository;
 import com.prothsync.prothsync.repository.repository.CommentRepository;
 import com.prothsync.prothsync.repository.repository.PostLikeRepository;
 import com.prothsync.prothsync.repository.repository.PostRepository;
+import com.prothsync.prothsync.repository.repository.RefreshTokenRepository;
 import com.prothsync.prothsync.repository.repository.ReportRepository;
 import com.prothsync.prothsync.repository.repository.UserRepository;
 import java.util.List;
@@ -48,6 +49,7 @@ public class AdminService {
     private final HashtagService hashtagService;
     private final PostImageService postImageService;
     private final CommentService commentService;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     @Transactional(readOnly = true)
     public PageResponse<ReportResponseDTO> getReports(ReportStatus status, Pageable pageable) {
@@ -110,6 +112,8 @@ public class AdminService {
 
         user.suspend(request.reason(), request.suspendUntil());
         userRepository.save(user);
+
+        refreshTokenRepository.deleteByUserId(userId);
 
         return AdminUserResponseDTO.from(user);
     }


### PR DESCRIPTION
# 변경사항
- AdminService.suspenUser() 호출 시 정지 대상 유저의 Refresh Token을 즉시 삭제하여, 새로운 Aceess Token 발급 경로를 차단합니다.

# 문제점
## 기존 상황
- 관리자가 사용자를 정지하면 User 엔티티의 상태만 변경되고, 해당 사용자의 Refresh Token은 DB에 그대로 남아있었습니다.
그래서 2가지 문제점이 발생했습니다.

1. RefreshToken으로 새 Access Token 발급 가능
- 정지된 유저가 Refresh api 호출하면 user.isSuspended() 체크에 걸리긴 하지만, 이는 Service 레이어에서의 방어리 뿐 토큰 자체가 유효한 상태로 남아있었습니다.

2. 기존 Access Token 만료 시점까지 API 호출 가능
- JwtFilter에서 isAccdountNonLocked() 체크로 차단하고 있지만, 이는 매 요청마다 CustomUserDetailsService.loadUserById()를 통해 DB를 계속 조회하는 비용이 발생했습니다. 

그래서 즉시 Refresh Token을 삭제하는 방향으로 수정하였습니다.