### PR TITLE
fix: 좋아요 수 오류 수정

### DIFF
--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/PostRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/PostRepositoryImpl.java
@@ -78,4 +78,14 @@ public class PostRepositoryImpl implements PostRepository {
     public void incrementViewCount(Long postId, int delta){
         postJpaRepository.incrementViewCount(postId,delta);
     }
+
+    @Override
+    public void incrementLikeCount(Long postId){
+        postJpaRepository.incrementLikeCount(postId);
+    }
+
+    @Override
+    public void decrementLikeCount(Long postId){
+        postJpaRepository.decrementLikeCount(postId);
+    }
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/PostJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/PostJpaRepository.java
@@ -42,4 +42,12 @@ public interface PostJpaRepository extends JpaRepository<Post, Long> {
     @Modifying
     @Query("UPDATE Post p SET p.viewCount = p.viewCount + :delta WHERE p.postId = :postId")
     void incrementViewCount(@Param("postId") Long postId, @Param("delta") int delta);
+
+    @Modifying
+    @Query("UPDATE Post p Set p.likeCount = p.likeCount + 1 WHERE p.postId = :postId")
+    void incrementLikeCount(@Param("postId") Long postId);
+
+    @Modifying
+    @Query("UPDATE Post p SET p.likeCount = p.likeCount - 1 WHERE p.postId = :postId AND p.likeCount > 0")
+    void decrementLikeCount(@Param("postId") Long postId);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/PostRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/PostRepository.java
@@ -29,4 +29,7 @@ public interface PostRepository {
     List<Post> findAllByIds(List<Long> postIds);
 
     void incrementViewCount(Long postId, int delta);
+
+    void incrementLikeCount(Long postId);
+    void decrementLikeCount(Long postId);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/LikeService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/LikeService.java
@@ -31,20 +31,18 @@ public class LikeService {
 
         if (existingLike.isPresent()) {
             postLikeRepository.delete(existingLike.get());
-            post.decrementLikeCount();
-            postRepository.save(post);
-            return LikeResponseDTO.of(postId, false, post.getLikeCount());
+            postRepository.decrementLikeCount(postId);
+            return LikeResponseDTO.of(postId, false, post.getLikeCount() - 1);
         } else {
             blockService.validateNotBlocked(userId, post.getUserId());
             PostLike postLike = PostLike.create(userId, postId);
             postLikeRepository.save(postLike);
-            post.incrementLikeCount();
-            postRepository.save(post);
+            postRepository.incrementLikeCount(postId);
 
             notificationService.send(
-                NotificationType.LIKE,userId,post.getUserId(),postId, ReferenceType.POST
+                NotificationType.LIKE, userId, post.getUserId(), postId, ReferenceType.POST
             );
-            return LikeResponseDTO.of(postId, true, post.getLikeCount());
+            return LikeResponseDTO.of(postId, true, post.getLikeCount() + 1);
         }
     }
 


### PR DESCRIPTION
# 변경사항
- 코드 수정 전에는 좋아요 수 관련해서 A,B 사람이 좋아요 수 5 개인 게시물에 대해 좋아요를 동시에 누르게 된다면
- 7이 되어야 하는데 6이 되는 현상이 발생했습니다. 
- 그래서 이를 수정해서 쿼리문으로 +1하면서 문제를 해결했습니다.