### PR TITLE
fix: 댓글 수 오류 수정

### DIFF
--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/PostRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/PostRepositoryImpl.java
@@ -88,4 +88,14 @@ public class PostRepositoryImpl implements PostRepository {
     public void decrementLikeCount(Long postId){
         postJpaRepository.decrementLikeCount(postId);
     }
+
+    @Override
+    public void incrementCommentCount(Long postId) {
+        postJpaRepository.incrementCommentCount(postId);
+    }
+
+    @Override
+    public void decrementCommentCount(Long postId) {
+        postJpaRepository.decrementCommentCount(postId);
+    }
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/PostJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/PostJpaRepository.java
@@ -50,4 +50,12 @@ public interface PostJpaRepository extends JpaRepository<Post, Long> {
     @Modifying
     @Query("UPDATE Post p SET p.likeCount = p.likeCount - 1 WHERE p.postId = :postId AND p.likeCount > 0")
     void decrementLikeCount(@Param("postId") Long postId);
+
+    @Modifying
+    @Query("UPDATE Post p SET p.commentCount = p.commentCount + 1 WHERE p.postId = :postId")
+    void incrementCommentCount(@Param("postId") Long postId);
+
+    @Modifying
+    @Query("UPDATE Post p SET p.commentCount = p.commentCount - 1 WHERE p.postId = :postId AND p.commentCount > 0")
+    void decrementCommentCount(@Param("postId") Long postId);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/PostRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/PostRepository.java
@@ -32,4 +32,7 @@ public interface PostRepository {
 
     void incrementLikeCount(Long postId);
     void decrementLikeCount(Long postId);
+
+    void incrementCommentCount(Long postId);
+    void decrementCommentCount(Long postId);
 }

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/AdminService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/AdminService.java
@@ -169,11 +169,7 @@ public class AdminService {
         Comment comment = commentRepository.findById(commentId)
             .orElseThrow(() -> new BusinessException(PostErrorCode.COMMENT_NOT_FOUND));
 
-        Post post = postRepository.findById(comment.getPostId())
-            .orElseThrow(() -> new BusinessException(PostErrorCode.POST_NOT_FOUND));
-
-        post.decrementCommentCount();
-        postRepository.save(post);
+        postRepository.decrementCommentCount(comment.getPostId());
 
         commentRepository.softDelete(comment, adminUserId);
     }

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/CommentService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/CommentService.java
@@ -37,8 +37,7 @@ public class CommentService {
         Comment comment = Comment.createComment(postId, userId, request.content());
         Comment savedComment = commentRepository.save(comment);
 
-        post.incrementCommentCount();
-        postRepository.save(post);
+        postRepository.incrementCommentCount(postId);
 
         notificationService.send(
             NotificationType.COMMENT, userId, post.getUserId(),
@@ -76,9 +75,7 @@ public class CommentService {
         Comment comment = findCommentOrThrow(commentId);
         validateCommentOwner(comment, userId);
 
-        Post post = findPostOrThrow(comment.getPostId());
-        post.decrementCommentCount();
-        postRepository.save(post);
+        postRepository.decrementCommentCount(comment.getPostId());
 
         commentRepository.softDelete(comment, userId);
     }


### PR DESCRIPTION
# 변경사항
- 댓글 수 관련해서도 수정작업을 진행하였습니다.
- 그 전에 댓글 수 관련해서는 Post를 불러와서 그 Post에서 메서드로 내리거나 올렸는데 JpaRepository에서 관리하게 변경하였습니다.

# 변경 전
엔티티 단위로 작업을 진행 VS DB단위로 작업
이렇게 두었을 때 동시성 단위로 보았을 때 DB로 단위로 작업하는 것이 변화를 놓치지 않을 것 같아 이 방법으로 수정하였습니다.