### PR TITLE
fix: 차단한 유저, 게시물 DB 단위에서 처리

### DIFF
--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/PostRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/PostRepositoryImpl.java
@@ -65,6 +65,13 @@ public class PostRepositoryImpl implements PostRepository {
     }
 
     @Override
+    public Page<Post> findAllByHashtagIdAndVisibilityPublicExcludingBlockedUsers(
+        Long hashtagId, Long currentUserId, Pageable pageable) {
+        return postJpaRepository.findAllByHashtagIdAndVisibilityPublicExcludingBlockedUsers(
+            hashtagId, currentUserId, pageable);
+    }
+
+    @Override
     public long count() {
         return postJpaRepository.count();
     }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/UserRepositoryImpl.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/impl/UserRepositoryImpl.java
@@ -81,6 +81,12 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
+    public Page<User> searchByNickNameExcludingBlockedUsers(
+        String keyword, Long currentUserId, Pageable pageable) {
+        return userJpaRepository.searchByNickNameExcludingBlockedUsers(keyword, currentUserId, pageable);
+    }
+
+    @Override
     public Page<User> findAll(Pageable pageable) {
         return userJpaRepository.findAll(pageable);
     }

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/PostJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/PostJpaRepository.java
@@ -37,6 +37,22 @@ public interface PostJpaRepository extends JpaRepository<Post, Long> {
     Page<Post> findAllByHashtagIdAndVisibilityPublic(
         @Param("hashtagId") Long hashtagId, Pageable pageable);
 
+    @Query("""
+        SELECT p FROM Post p
+        WHERE p.postId IN (
+            SELECT ph.postId FROM PostHashtag ph WHERE ph.hashtagId = :hashtagId
+        )
+        AND p.visibility = 'PUBLIC'
+        AND p.userId NOT IN (
+            SELECT b.blockedId FROM Block b WHERE b.blockerId = :currentUserId
+        )
+        ORDER BY p.createdAt DESC
+        """)
+    Page<Post> findAllByHashtagIdAndVisibilityPublicExcludingBlockedUsers(
+        @Param("hashtagId") Long hashtagId,
+        @Param("currentUserId") Long currentUserId,
+        Pageable pageable);
+
     List<Post> findAllByPostIdIn(List<Long> postIds);
 
     @Modifying

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/UserJpaRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/jpa/UserJpaRepository.java
@@ -108,6 +108,18 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
 
     Page<User> findByNickNameContainingIgnoreCase(String keyword, Pageable pageable);
 
+    @Query("""
+        SELECT u FROM User u
+        WHERE LOWER(u.nickName) LIKE LOWER(CONCAT('%', :keyword, '%'))
+        AND u.userId NOT IN (
+            SELECT b.blockedId FROM Block b WHERE b.blockerId = :currentUserId
+        )
+        """)
+    Page<User> searchByNickNameExcludingBlockedUsers(
+        @Param("keyword") String keyword,
+        @Param("currentUserId") Long currentUserId,
+        Pageable pageable);
+
     Page<User> findAll(Pageable pageable);
 
     @Modifying

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/PostRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/PostRepository.java
@@ -24,6 +24,9 @@ public interface PostRepository {
 
     Page<Post> findAllByHashtagIdAndVisibilityPublic(Long hashtagId, Pageable pageable);
 
+    Page<Post> findAllByHashtagIdAndVisibilityPublicExcludingBlockedUsers(
+        Long hashtagId, Long currentUserId, Pageable pageable);
+
     long count();
 
     List<Post> findAllByIds(List<Long> postIds);

--- a/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/UserRepository.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/repository/repository/UserRepository.java
@@ -26,6 +26,9 @@ public interface UserRepository {
 
     Page<User> searchByNickName(String keyword, Pageable pageable);
 
+    Page<User> searchByNickNameExcludingBlockedUsers(
+        String keyword, Long currentUserId, Pageable pageable);
+
     Page<User> findAll(Pageable pageable);
 
     long count();

--- a/prothsync/src/main/java/com/prothsync/prothsync/service/SearchService.java
+++ b/prothsync/src/main/java/com/prothsync/prothsync/service/SearchService.java
@@ -10,7 +10,6 @@ import com.prothsync.prothsync.exception.BusinessException;
 import com.prothsync.prothsync.exception.PostErrorCode;
 import com.prothsync.prothsync.exception.SearchErrorCode;
 import com.prothsync.prothsync.global.PageResponse;
-import com.prothsync.prothsync.repository.repository.BlockRepository;
 import com.prothsync.prothsync.repository.repository.HashtagRepository;
 import com.prothsync.prothsync.repository.repository.PostRepository;
 import com.prothsync.prothsync.repository.repository.UserRepository;
@@ -33,7 +32,6 @@ public class SearchService {
     private final PostRepository postRepository;
     private final UserRepository userRepository;
     private final PostImageService postImageService;
-    private final BlockRepository blockRepository;
 
     public PageResponse<HashtagResponseDTO> searchHashtags(String keyword, Pageable pageable) {
         validateKeyword(keyword);
@@ -58,22 +56,22 @@ public class SearchService {
         Hashtag hashtag = hashtagRepository.findByTagName(normalizedName)
             .orElseThrow(() -> new BusinessException(PostErrorCode.HASHTAG_NOT_FOUND));
 
-        Page<Post> postPage = postRepository.findAllByHashtagIdAndVisibilityPublic(
-            hashtag.getHashtagId(), pageable);
+        Page<Post> postPage;
+        if (currentUserId != null) {
+            postPage = postRepository.findAllByHashtagIdAndVisibilityPublicExcludingBlockedUsers(
+                hashtag.getHashtagId(), currentUserId, pageable);
+        } else {
+            postPage = postRepository.findAllByHashtagIdAndVisibilityPublic(
+                hashtag.getHashtagId(), pageable);
+        }
 
-        List<Long> blockedIds = getBlockedIds(currentUserId);
-
-        List<Post> filteredPosts = postPage.getContent().stream()
-            .filter(post -> !blockedIds.contains(post.getUserId()))
-            .toList();
-
-        List<Long> postIds = filteredPosts.stream()
+        List<Long> postIds = postPage.getContent().stream()
             .map(Post::getPostId)
             .toList();
 
         Map<Long, String> thumbnailMap = postImageService.getThumbnailUrls(postIds);
 
-        List<PostSummaryResponseDTO> summaries = filteredPosts.stream()
+        List<PostSummaryResponseDTO> summaries = postPage.getContent().stream()
             .map(post -> PostSummaryResponseDTO.of(
                 post, thumbnailMap.get(post.getPostId())))
             .toList();
@@ -81,19 +79,20 @@ public class SearchService {
         return PageResponse.of(summaries, postPage);
     }
 
-
-
     public PageResponse<UserSearchResponseDTO> searchUsers(
         String keyword, Long currentUserId, Pageable pageable) {
 
         validateKeyword(keyword);
 
-        Page<User> userPage = userRepository.searchByNickName(keyword.trim(), pageable);
-
-        List<Long> blockedIds = getBlockedIds(currentUserId);
+        Page<User> userPage;
+        if (currentUserId != null) {
+            userPage = userRepository.searchByNickNameExcludingBlockedUsers(
+                keyword.trim(), currentUserId, pageable);
+        } else {
+            userPage = userRepository.searchByNickName(keyword.trim(), pageable);
+        }
 
         List<UserSearchResponseDTO> users = userPage.getContent().stream()
-            .filter(user -> !blockedIds.contains(user.getUserId()))
             .map(UserSearchResponseDTO::from)
             .toList();
 
@@ -113,12 +112,5 @@ public class SearchService {
         return keyword.trim()
             .replaceAll("^#+", "")
             .toLowerCase();
-    }
-
-    private List<Long> getBlockedIds(Long currentUserId) {
-        if (currentUserId == null) {
-            return List.of();
-        }
-        return blockRepository.findBlockedIdsByBlockerId(currentUserId);
     }
 }


### PR DESCRIPTION
# 변경사항
- SearchService의 해시태그 게시물 검색과 유저 검색에서 차단 유저 필터링을 Application 레벨 stream().filter() 에서 DB에서 Not IN 서브쿼리로 변경하였습니다.

## 기존 문제점
```
DB에서 Page<Post> 조회 (size=10, totalElements=25)
    → Application에서 blockedIds로 stream().filter()
    → 차단 유저 게시물 3개 제거
    → 실제 반환: 7개
    → 그러나 PageResponse의 totalElements는 여전히 25
```
- 이로 인해 페이지네이션 데이터 부정확하여 페이지 크기와 결과값이 다른 현상이 있어 수정하였습니다. 